### PR TITLE
Possibility to dump tree as json

### DIFF
--- a/jsonify.go
+++ b/jsonify.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Karl Gaissmaier
+// SPDX-License-Identifier: MIT
+
+package bart
+
+import (
+	"encoding/json"
+	"net/netip"
+	"slices"
+)
+
+type ListElement[V any] struct {
+	Cidr    netip.Prefix     `json:"cidr"`
+	Value   V                `json:"value"`
+	Subnets []ListElement[V] `json:"subnets,omitempty"`
+}
+
+// MarshalJSON dumps table into two lists: for ipv4 and ipv6
+// every root and subnets are array, not map (cidr -> {value,subnets}), because the order matters
+func (t *Table[V]) MarshalJSON() ([]byte, error) {
+	t.init()
+
+	result := struct {
+		Ipv4 []ListElement[V] `json:"ipv4,omitempty"`
+		Ipv6 []ListElement[V] `json:"ipv6,omitempty"`
+	}{}
+
+	var err error
+	result.Ipv4, err = t.DumpList(true)
+	if err != nil {
+		return nil, err
+	}
+	result.Ipv6, err = t.DumpList(false)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+// DumpList dumps ipv4 od ipv6 tree into list of roots and their children
+func (t *Table[V]) DumpList(is4 bool) ([]ListElement[V], error) {
+	t.init()
+	rootNode := t.rootNodeByVersion(is4)
+	if rootNode.isEmpty() {
+		return nil, nil
+	}
+
+	elements, err := rootNode.dumpList(0, nil, is4)
+	if err != nil {
+		return nil, err
+	}
+
+	return elements, nil
+}
+
+func (n *node[V]) dumpList(parentIdx uint, path []byte, is4 bool) ([]ListElement[V], error) {
+	directKids := n.getKidsRec(parentIdx, path, is4)
+	slices.SortFunc(directKids, sortPrefix[V])
+
+	elements := make([]ListElement[V], 0, len(directKids))
+	for _, kid := range directKids {
+		element := ListElement[V]{
+			Cidr:  kid.cidr,
+			Value: kid.val,
+		}
+
+		subnetList, err := kid.n.dumpList(kid.idx, kid.path, is4)
+		if err != nil {
+			return nil, err
+		}
+		element.Subnets = subnetList
+
+		elements = append(elements, element)
+	}
+
+	return elements, nil
+}

--- a/jsonify.go
+++ b/jsonify.go
@@ -9,8 +9,9 @@ import (
 	"slices"
 )
 
+// ListElement contains CIDR, value and list of subnets (tree childrens).
 type ListElement[V any] struct {
-	Cidr    netip.Prefix     `json:"cidr"`
+	CIDR    netip.Prefix     `json:"cidr"`
 	Value   V                `json:"value"`
 	Subnets []ListElement[V] `json:"subnets,omitempty"`
 }
@@ -55,7 +56,7 @@ func (n *node[V]) dumpListRec(parentIdx uint, path []byte, is4 bool) []ListEleme
 	elements := make([]ListElement[V], 0, len(directKids))
 	for _, kid := range directKids {
 		elements = append(elements, ListElement[V]{
-			Cidr:    kid.cidr,
+			CIDR:    kid.cidr,
 			Value:   kid.val,
 			Subnets: kid.n.dumpListRec(kid.idx, kid.path, is4),
 		})

--- a/jsonify.go
+++ b/jsonify.go
@@ -15,8 +15,8 @@ type ListElement[V any] struct {
 	Subnets []ListElement[V] `json:"subnets,omitempty"`
 }
 
-// MarshalJSON dumps table into two lists: for ipv4 and ipv6
-// every root and subnets are array, not map (cidr -> {value,subnets}), because the order matters
+// MarshalJSON dumps table into two sorted lists: for ipv4 and ipv6.
+// Every root and subnet are array, not map, because the order matters.
 func (t *Table[V]) MarshalJSON() ([]byte, error) {
 	t.init()
 
@@ -36,7 +36,8 @@ func (t *Table[V]) MarshalJSON() ([]byte, error) {
 	return buf, nil
 }
 
-// DumpList dumps ipv4 od ipv6 tree into list of roots and their children
+// DumpList dumps ipv4 or ipv6 tree into list of roots and their subnets.
+// It can be used to analyze tree or build custom json representation.
 func (t *Table[V]) DumpList(is4 bool) []ListElement[V] {
 	t.init()
 	rootNode := t.rootNodeByVersion(is4)

--- a/jsonify_test.go
+++ b/jsonify_test.go
@@ -1,0 +1,211 @@
+package bart
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+)
+
+type jsonTestElement struct {
+	cidr  netip.Prefix
+	value any
+}
+
+func newJsonTestElement(cidr string, value any) jsonTestElement {
+	return jsonTestElement{
+		cidr:  netip.MustParsePrefix(cidr),
+		value: value,
+	}
+}
+
+type jsonTest struct {
+	elements []jsonTestElement
+	want     string
+}
+
+func TestJsonEmpty(t *testing.T) {
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{},
+		want:     "{}",
+	})
+}
+
+func TestJsonDefaultRouteV4(t *testing.T) {
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{
+			newJsonTestElement("0.0.0.0/0", nil),
+		},
+		want: `{"ipv4":[{"cidr":"0.0.0.0/0","value":null}]}`,
+	})
+}
+
+func TestJsonDefaultRouteV6(t *testing.T) {
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{
+			newJsonTestElement("::/0", 31337),
+		},
+		want: `{"ipv6":[{"cidr":"::/0","value":31337}]}`,
+	})
+}
+
+func TestJsonSampleV4(t *testing.T) {
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{
+			newJsonTestElement("172.16.0.0/12", nil),
+			newJsonTestElement("10.0.0.0/24", nil),
+			newJsonTestElement("192.168.0.0/16", nil),
+			newJsonTestElement("10.0.0.0/8", nil),
+			newJsonTestElement("10.0.1.0/24", nil),
+			newJsonTestElement("169.254.0.0/16", nil),
+			newJsonTestElement("127.0.0.0/8", nil),
+			newJsonTestElement("127.0.0.1/32", nil),
+			newJsonTestElement("192.168.1.0/24", nil),
+		},
+		/*
+		   {
+		     "ipv4": [
+		       {
+		         "cidr": "10.0.0.0/8",
+		         "value": null,
+		         "subnets": [
+		           { "cidr": "10.0.0.0/24", "value": null },
+		           { "cidr": "10.0.1.0/24", "value": null }
+		         ]
+		       },
+		       {
+		         "cidr": "127.0.0.0/8",
+		         "value": null,
+		         "subnets": [{ "cidr": "127.0.0.1/32", "value": null }]
+		       },
+		       { "cidr": "169.254.0.0/16", "value": null },
+		       { "cidr": "172.16.0.0/12", "value": null },
+		       {
+		         "cidr": "192.168.0.0/16",
+		         "value": null,
+		         "subnets": [{ "cidr": "192.168.1.0/24", "value": null }]
+		       }
+		     ]
+		   }
+		*/
+		want: `{"ipv4":[{"cidr":"10.0.0.0/8","value":null,"subnets":[{"cidr":"10.0.0.0/24","value":null},{"cidr":"10.0.1.0/24","value":null}]},{"cidr":"127.0.0.0/8","value":null,"subnets":[{"cidr":"127.0.0.1/32","value":null}]},{"cidr":"169.254.0.0/16","value":null},{"cidr":"172.16.0.0/12","value":null},{"cidr":"192.168.0.0/16","value":null,"subnets":[{"cidr":"192.168.1.0/24","value":null}]}]}`,
+	})
+}
+
+func TestJsonSampleV6(t *testing.T) {
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{
+			newJsonTestElement("fe80::/10", nil),
+			newJsonTestElement("::1/128", nil),
+			newJsonTestElement("2000::/3", nil),
+			newJsonTestElement("2001:db8::/32", nil),
+		},
+		/*
+			{
+			  "ipv6": [
+			    { "cidr": "::1/128", "value": null },
+			    {
+			      "cidr": "2000::/3",
+			      "value": null,
+			      "subnets": [{ "cidr": "2001:db8::/32", "value": null }]
+			    },
+			    { "cidr": "fe80::/10", "value": null }
+			  ]
+			}
+		*/
+		want: `{"ipv6":[{"cidr":"::1/128","value":null},{"cidr":"2000::/3","value":null,"subnets":[{"cidr":"2001:db8::/32","value":null}]},{"cidr":"fe80::/10","value":null}]}`,
+	})
+}
+
+func TestJsonSample(t *testing.T) {
+	// ipv4 + ipv6 and various types of value
+	tbl := new(Table[any])
+	checkJson(t, tbl, jsonTest{
+		elements: []jsonTestElement{
+			newJsonTestElement("fe80::/10", nil),
+			newJsonTestElement("172.16.0.0/12", nil),
+			newJsonTestElement("10.0.0.0/24", nil),
+			newJsonTestElement("::1/128", nil),
+			newJsonTestElement("10.0.0.0/8", nil),
+			newJsonTestElement("::/0", nil),
+			newJsonTestElement("10.0.1.0/24", nil),
+			newJsonTestElement("2000::/3", nil),
+			newJsonTestElement("2001:db8::/32", nil),
+			// some different value types:
+			newJsonTestElement("127.0.0.0/8", 31337),
+			newJsonTestElement("169.254.0.0/16", 3.14),
+			newJsonTestElement("127.0.0.1/32", "some string"),
+			newJsonTestElement("192.168.0.0/16", []string{"a", "c", "ff"}),
+			newJsonTestElement("192.168.1.0/24", "550e8400-e29b-41d4-a716-446655440000"),
+		},
+		/*
+			{
+			  "ipv4": [
+			    {
+			      "cidr": "10.0.0.0/8",
+			      "value": null,
+			      "subnets": [
+			        { "cidr": "10.0.0.0/24", "value": null },
+			        { "cidr": "10.0.1.0/24", "value": null }
+			      ]
+			    },
+			    {
+			      "cidr": "127.0.0.0/8",
+			      "value": 31337,
+			      "subnets": [{ "cidr": "127.0.0.1/32", "value": "some string" }]
+			    },
+			    { "cidr": "169.254.0.0/16", "value": 3.14 },
+			    { "cidr": "172.16.0.0/12", "value": null },
+			    {
+			      "cidr": "192.168.0.0/16",
+			      "value": ["a", "c", "ff"],
+			      "subnets": [
+			        {
+			          "cidr": "192.168.1.0/24",
+			          "value": "550e8400-e29b-41d4-a716-446655440000"
+			        }
+			      ]
+			    }
+			  ],
+			  "ipv6": [
+			    {
+			      "cidr": "::/0",
+			      "value": null,
+			      "subnets": [
+			        { "cidr": "::1/128", "value": null },
+			        {
+			          "cidr": "2000::/3",
+			          "value": null,
+			          "subnets": [{ "cidr": "2001:db8::/32", "value": null }]
+			        },
+			        { "cidr": "fe80::/10", "value": null }
+			      ]
+			    }
+			  ]
+			}
+
+		*/
+		want: `{"ipv4":[{"cidr":"10.0.0.0/8","value":null,"subnets":[{"cidr":"10.0.0.0/24","value":null},{"cidr":"10.0.1.0/24","value":null}]},{"cidr":"127.0.0.0/8","value":31337,"subnets":[{"cidr":"127.0.0.1/32","value":"some string"}]},{"cidr":"169.254.0.0/16","value":3.14},{"cidr":"172.16.0.0/12","value":null},{"cidr":"192.168.0.0/16","value":["a","c","ff"],"subnets":[{"cidr":"192.168.1.0/24","value":"550e8400-e29b-41d4-a716-446655440000"}]}],"ipv6":[{"cidr":"::/0","value":null,"subnets":[{"cidr":"::1/128","value":null},{"cidr":"2000::/3","value":null,"subnets":[{"cidr":"2001:db8::/32","value":null}]},{"cidr":"fe80::/10","value":null}]}]}`,
+	})
+}
+
+func checkJson(t *testing.T, tbl *Table[any], tt jsonTest) {
+	t.Helper()
+	for _, element := range tt.elements {
+		tbl.Insert(element.cidr, element.value)
+	}
+
+	jsonBuffer, err := json.Marshal(tbl)
+	if err != nil {
+		t.Errorf("Json marshal got error: %s", err)
+	}
+
+	got := string(jsonBuffer)
+	if tt.want != got {
+		t.Errorf("String got:\n%s\nwant:\n%s\n%s", got, tt.want, tt.want)
+	}
+}

--- a/jsonify_test.go
+++ b/jsonify_test.go
@@ -206,6 +206,6 @@ func checkJson(t *testing.T, tbl *Table[any], tt jsonTest) {
 
 	got := string(jsonBuffer)
 	if tt.want != got {
-		t.Errorf("String got:\n%s\nwant:\n%s\n%s", got, tt.want, tt.want)
+		t.Errorf("String got:\n%s\nwant:\n%s", got, tt.want)
 	}
 }

--- a/jsonify_test.go
+++ b/jsonify_test.go
@@ -6,36 +6,36 @@ import (
 	"testing"
 )
 
-type jsonTestElement struct {
+type jsonTestNode struct {
 	cidr  netip.Prefix
 	value any
 }
 
-func newJsonTestElement(cidr string, value any) jsonTestElement {
-	return jsonTestElement{
+func newJsonTestNode(cidr string, value any) jsonTestNode {
+	return jsonTestNode{
 		cidr:  netip.MustParsePrefix(cidr),
 		value: value,
 	}
 }
 
 type jsonTest struct {
-	elements []jsonTestElement
-	want     string
+	nodes []jsonTestNode
+	want  string
 }
 
 func TestJsonEmpty(t *testing.T) {
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{},
-		want:     "{}",
+		nodes: []jsonTestNode{},
+		want:  "{}",
 	})
 }
 
 func TestJsonDefaultRouteV4(t *testing.T) {
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{
-			newJsonTestElement("0.0.0.0/0", nil),
+		nodes: []jsonTestNode{
+			newJsonTestNode("0.0.0.0/0", nil),
 		},
 		want: `{"ipv4":[{"cidr":"0.0.0.0/0","value":null}]}`,
 	})
@@ -44,8 +44,8 @@ func TestJsonDefaultRouteV4(t *testing.T) {
 func TestJsonDefaultRouteV6(t *testing.T) {
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{
-			newJsonTestElement("::/0", 31337),
+		nodes: []jsonTestNode{
+			newJsonTestNode("::/0", 31337),
 		},
 		want: `{"ipv6":[{"cidr":"::/0","value":31337}]}`,
 	})
@@ -54,16 +54,16 @@ func TestJsonDefaultRouteV6(t *testing.T) {
 func TestJsonSampleV4(t *testing.T) {
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{
-			newJsonTestElement("172.16.0.0/12", nil),
-			newJsonTestElement("10.0.0.0/24", nil),
-			newJsonTestElement("192.168.0.0/16", nil),
-			newJsonTestElement("10.0.0.0/8", nil),
-			newJsonTestElement("10.0.1.0/24", nil),
-			newJsonTestElement("169.254.0.0/16", nil),
-			newJsonTestElement("127.0.0.0/8", nil),
-			newJsonTestElement("127.0.0.1/32", nil),
-			newJsonTestElement("192.168.1.0/24", nil),
+		nodes: []jsonTestNode{
+			newJsonTestNode("172.16.0.0/12", nil),
+			newJsonTestNode("10.0.0.0/24", nil),
+			newJsonTestNode("192.168.0.0/16", nil),
+			newJsonTestNode("10.0.0.0/8", nil),
+			newJsonTestNode("10.0.1.0/24", nil),
+			newJsonTestNode("169.254.0.0/16", nil),
+			newJsonTestNode("127.0.0.0/8", nil),
+			newJsonTestNode("127.0.0.1/32", nil),
+			newJsonTestNode("192.168.1.0/24", nil),
 		},
 		/*
 		   {
@@ -98,11 +98,11 @@ func TestJsonSampleV4(t *testing.T) {
 func TestJsonSampleV6(t *testing.T) {
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{
-			newJsonTestElement("fe80::/10", nil),
-			newJsonTestElement("::1/128", nil),
-			newJsonTestElement("2000::/3", nil),
-			newJsonTestElement("2001:db8::/32", nil),
+		nodes: []jsonTestNode{
+			newJsonTestNode("fe80::/10", nil),
+			newJsonTestNode("::1/128", nil),
+			newJsonTestNode("2000::/3", nil),
+			newJsonTestNode("2001:db8::/32", nil),
 		},
 		/*
 			{
@@ -125,22 +125,22 @@ func TestJsonSample(t *testing.T) {
 	// ipv4 + ipv6 and various types of value
 	tbl := new(Table[any])
 	checkJson(t, tbl, jsonTest{
-		elements: []jsonTestElement{
-			newJsonTestElement("fe80::/10", nil),
-			newJsonTestElement("172.16.0.0/12", nil),
-			newJsonTestElement("10.0.0.0/24", nil),
-			newJsonTestElement("::1/128", nil),
-			newJsonTestElement("10.0.0.0/8", nil),
-			newJsonTestElement("::/0", nil),
-			newJsonTestElement("10.0.1.0/24", nil),
-			newJsonTestElement("2000::/3", nil),
-			newJsonTestElement("2001:db8::/32", nil),
+		nodes: []jsonTestNode{
+			newJsonTestNode("fe80::/10", nil),
+			newJsonTestNode("172.16.0.0/12", nil),
+			newJsonTestNode("10.0.0.0/24", nil),
+			newJsonTestNode("::1/128", nil),
+			newJsonTestNode("10.0.0.0/8", nil),
+			newJsonTestNode("::/0", nil),
+			newJsonTestNode("10.0.1.0/24", nil),
+			newJsonTestNode("2000::/3", nil),
+			newJsonTestNode("2001:db8::/32", nil),
 			// some different value types:
-			newJsonTestElement("127.0.0.0/8", 31337),
-			newJsonTestElement("169.254.0.0/16", 3.14),
-			newJsonTestElement("127.0.0.1/32", "some string"),
-			newJsonTestElement("192.168.0.0/16", []string{"a", "c", "ff"}),
-			newJsonTestElement("192.168.1.0/24", "550e8400-e29b-41d4-a716-446655440000"),
+			newJsonTestNode("127.0.0.0/8", 31337),
+			newJsonTestNode("169.254.0.0/16", 3.14),
+			newJsonTestNode("127.0.0.1/32", "some string"),
+			newJsonTestNode("192.168.0.0/16", []string{"a", "c", "ff"}),
+			newJsonTestNode("192.168.1.0/24", "550e8400-e29b-41d4-a716-446655440000"),
 		},
 		/*
 			{
@@ -195,8 +195,8 @@ func TestJsonSample(t *testing.T) {
 
 func checkJson(t *testing.T, tbl *Table[any], tt jsonTest) {
 	t.Helper()
-	for _, element := range tt.elements {
-		tbl.Insert(element.cidr, element.value)
+	for _, node := range tt.nodes {
+		tbl.Insert(node.cidr, node.value)
 	}
 
 	jsonBuffer, err := json.Marshal(tbl)


### PR DESCRIPTION
Hello,

I need possibility to dump tree to list of records (to store in DB for example), so I've added two methods:

- `MarshalJSON` to marshal tree (separated ipv4 and ipv6 keys) to json.

- `DumpList` to build custom json struct, use for example in database storage, or for debug purpose.

Test data is taken from `stringify_test.go`.