### PR TITLE
remove toolchain line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/gaissmai/bart
 go 1.24.0
 
 retract v0.20.5 // introduced a bug in InsertPersist
-
-toolchain go1.25.0


### PR DESCRIPTION
The `toolchain` line is just as infectious as the `go` line. Modules requiring `bart` will inherit the same toolchain version requirement.

The `x/*` modules explicitly do toolchain line removal as a upgrade step, see for example golang/sys@543f21a0561186ad3f71483165a2a1dc32dbae4c. Running `go get toolchain@1.24.0` also has the same effect.