### PR TITLE
changed signature of Delete and DeletePersist

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,23 +76,21 @@ See the `ExampleLite_concurrent` and `ExampleTable_concurrent` tests for concret
   }
 
   func (t *Table[V]) Contains(ip netip.Addr) bool
-  func (t *Table[V]) Lookup(ip netip.Addr) (val V, ok bool)
+  func (t *Table[V]) Lookup(ip netip.Addr) (V, bool)
 
-  func (t *Table[V]) LookupPrefix(pfx netip.Prefix) (val V, ok bool)
-  func (t *Table[V]) LookupPrefixLPM(pfx netip.Prefix) (lpm netip.Prefix, val V, ok bool)
+  func (t *Table[V]) LookupPrefix(pfx netip.Prefix) (V, bool)
+  func (t *Table[V]) LookupPrefixLPM(pfx netip.Prefix) (netip.Prefix, V, bool)
 
   func (t *Table[V]) Insert(pfx netip.Prefix, val V)
-  func (t *Table[V]) Delete(pfx netip.Prefix)
   func (t *Table[V]) Modify(pfx netip.Prefix, func(V, bool) (V, bool)) (V, bool)
+  func (t *Table[V]) Delete(pfx netip.Prefix) (V, bool)
+  func (t *Table[V]) Get(pfx netip.Prefix) (V, bool)
 
   func (t *Table[V]) InsertPersist(pfx netip.Prefix, val V) *Table[V]
-  func (t *Table[V]) DeletePersist(pfx netip.Prefix) *Table[V]
   func (t *Table[V]) ModifyPersist(pfx netip.Prefix, func(val V, ok bool) (V, bool)) (*Table[V], V, bool)
+  func (t *Table[V]) DeletePersist(pfx netip.Prefix) (*Table[V], V, bool)
   func (t *Table[V]) WalkPersist(func(*Table[V], netip.Prefix, V) (*Table[V], bool)) *Table[V]
 
-  func (t *Table[V]) Get(pfx netip.Prefix) (val V, ok bool)
-  func (t *Table[V]) GetAndDelete(pfx netip.Prefix) (val V, ok bool)
-  func (t *Table[V]) GetAndDeletePersist(pfx netip.Prefix) (pt *Table[V], val V, ok bool)
 
   func (t *Table[V]) Clone() *Table[V]
   func (t *Table[V]) Union(o *Table[V])
@@ -151,7 +149,7 @@ Some delegated methods are pointless without a payload.
    func (l *Lite) Delete(pfx netip.Prefix)
 
    func (l *Lite) InsertPersist(pfx netip.Prefix) *Lite
-   func (l *Lite) DeletePersist(pfx netip.Prefix) *Lite
+   func (l *Lite) DeletePersist(pfx netip.Prefix) (*Lite, bool)
    func (l *Lite) WalkPersist(fn func(*Lite, netip.Prefix) (*Lite, bool)) *Lite
 
    func (l *Lite) Clone() *Lite

--- a/example_lite_concurrent_test.go
+++ b/example_lite_concurrent_test.go
@@ -64,7 +64,7 @@ func ExampleLite_concurrent() {
 
 			// batch of deletes
 			for _, pfx := range examplePrefixes {
-				tbl = tbl.DeletePersist(pfx)
+				tbl, _ = tbl.DeletePersist(pfx)
 			}
 
 			liteAtomicPtr.Store(tbl)

--- a/example_table_concurrent_test.go
+++ b/example_table_concurrent_test.go
@@ -84,7 +84,7 @@ func ExampleTable_concurrent() {
 
 			// batch of deletes
 			for _, pfx := range examplePrefixes {
-				tbl = tbl.DeletePersist(pfx)
+				tbl, _, _ = tbl.DeletePersist(pfx)
 			}
 
 			tblAtomicPtr.Store(tbl)

--- a/lite.go
+++ b/lite.go
@@ -15,8 +15,6 @@ import (
 // The following methods are pointless without a payload:
 //   - Lookup (use Contains)
 //   - Get (use Exists)
-//   - GetAndDelete
-//   - GetAndDeletePersist
 //   - Modify
 //   - ModifyPersist
 type Lite struct {
@@ -48,15 +46,16 @@ func (l *Lite) InsertPersist(pfx netip.Prefix) *Lite {
 }
 
 // Delete is a wrapper for the underlying table.
-func (l *Lite) Delete(pfx netip.Prefix) {
-	l.Table.Delete(pfx)
+func (l *Lite) Delete(pfx netip.Prefix) bool {
+	_, found := l.Table.Delete(pfx)
+	return found
 }
 
 // DeletePersist is an adapter for the underlying table.
-func (l *Lite) DeletePersist(pfx netip.Prefix) *Lite {
-	tbl := l.Table.DeletePersist(pfx)
+func (l *Lite) DeletePersist(pfx netip.Prefix) (*Lite, bool) {
+	tbl, _, found := l.Table.DeletePersist(pfx)
 	//nolint:govet // copy of *tbl is here by intention
-	return &Lite{*tbl}
+	return &Lite{*tbl}, found
 }
 
 // WalkPersist is an adapter for the underlying table.

--- a/lite_test.go
+++ b/lite_test.go
@@ -76,7 +76,7 @@ func TestLiteInvalid(t *testing.T) {
 			}
 		}(testname)
 
-		_ = tbl1.DeletePersist(zeroPfx)
+		_, _ = tbl1.DeletePersist(zeroPfx)
 	})
 
 	testname = "Contains"
@@ -160,7 +160,7 @@ func TestLiteDeletePersist(t *testing.T) {
 		// must not panic
 		tbl := new(Lite)
 		checkLiteNumNodes(t, tbl, 0)
-		tbl = tbl.DeletePersist(randomPrefix(prng))
+		tbl, _ = tbl.DeletePersist(randomPrefix(prng))
 		checkLiteNumNodes(t, tbl, 0)
 	})
 
@@ -172,7 +172,7 @@ func TestLiteDeletePersist(t *testing.T) {
 
 		tbl.Insert(mpp("10.0.0.0/8"))
 		checkLiteNumNodes(t, tbl, 1)
-		tbl = tbl.DeletePersist(mpp("10.0.0.0/8"))
+		tbl, _ = tbl.DeletePersist(mpp("10.0.0.0/8"))
 		checkLiteNumNodes(t, tbl, 0)
 	})
 
@@ -185,7 +185,7 @@ func TestLiteDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("192.168.0.1/32"))
 		checkLiteNumNodes(t, tbl, 1)
 
-		tbl = tbl.DeletePersist(mpp("192.168.0.1/32"))
+		tbl, _ = tbl.DeletePersist(mpp("192.168.0.1/32"))
 		checkLiteNumNodes(t, tbl, 0)
 	})
 
@@ -199,7 +199,7 @@ func TestLiteDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("192.180.0.1/32"))
 		checkLiteNumNodes(t, tbl, 2)
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkLiteNumNodes(t, tbl, 1)
 	})
 
@@ -215,7 +215,7 @@ func TestLiteDeletePersist(t *testing.T) {
 
 		checkLiteNumNodes(t, tbl, 2)
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkLiteNumNodes(t, tbl, 2)
 	})
 
@@ -231,7 +231,7 @@ func TestLiteDeletePersist(t *testing.T) {
 
 		checkLiteNumNodes(t, tbl, 2)
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkLiteNumNodes(t, tbl, 2)
 	})
 
@@ -244,7 +244,7 @@ func TestLiteDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("192.168.0.1/32"))
 		checkLiteNumNodes(t, tbl, 1)
 
-		tbl = tbl.DeletePersist(mpp("200.0.0.0/32"))
+		tbl, _ = tbl.DeletePersist(mpp("200.0.0.0/32"))
 		checkLiteNumNodes(t, tbl, 1)
 	})
 
@@ -259,7 +259,7 @@ func TestLiteDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("192.168.0.0/22"))
 		checkLiteNumNodes(t, tbl, 3)
 
-		tbl = tbl.DeletePersist(mpp("192.168.0.0/22"))
+		tbl, _ = tbl.DeletePersist(mpp("192.168.0.0/22"))
 		checkLiteNumNodes(t, tbl, 1)
 	})
 
@@ -270,7 +270,7 @@ func TestLiteDeletePersist(t *testing.T) {
 
 		tbl.Insert(mpp("0.0.0.0/0"))
 		tbl.Insert(mpp("::/0"))
-		tbl = tbl.DeletePersist(mpp("0.0.0.0/0"))
+		tbl, _ = tbl.DeletePersist(mpp("0.0.0.0/0"))
 
 		checkLiteNumNodes(t, tbl, 1)
 	})
@@ -284,10 +284,10 @@ func TestLiteDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("10.20.0.0/17"))
 		checkLiteNumNodes(t, tbl, 2)
 
-		tbl = tbl.DeletePersist(mpp("10.20.0.0/17"))
+		tbl, _ = tbl.DeletePersist(mpp("10.20.0.0/17"))
 		checkLiteNumNodes(t, tbl, 1)
 
-		tbl = tbl.DeletePersist(mpp("10.10.0.0/17"))
+		tbl, _ = tbl.DeletePersist(mpp("10.10.0.0/17"))
 		checkLiteNumNodes(t, tbl, 0)
 	})
 }
@@ -837,7 +837,8 @@ func TestLiteWalkPersist(t *testing.T) {
 				"fd00::/8",
 			},
 			fn: func(pl *Lite, pfx netip.Prefix) (*Lite, bool) {
-				return pl.DeletePersist(pfx), true // remove everything
+				prt, _ := pl.DeletePersist(pfx)
+				return prt, true // remove everything
 			},
 			wantRemain: []string{},
 		},
@@ -849,7 +850,7 @@ func TestLiteWalkPersist(t *testing.T) {
 			},
 			fn: func(pl *Lite, pfx netip.Prefix) (*Lite, bool) {
 				if pfx.Addr().Is4() {
-					pl = pl.DeletePersist(pfx)
+					pl, _ = pl.DeletePersist(pfx)
 				}
 				return pl, true
 			},

--- a/persist_test.go
+++ b/persist_test.go
@@ -123,7 +123,7 @@ func TestDeletePersistTable(t *testing.T) {
 
 	clone := orig
 	for _, pfx := range pfxs {
-		clone = clone.DeletePersist(pfx)
+		clone, _, _ = clone.DeletePersist(pfx)
 
 		// Deleted prefix should be absent in clone
 		_, ok := clone.Get(pfx)
@@ -198,7 +198,7 @@ func TestDeletePersistLite(t *testing.T) {
 
 	clone := orig
 	for i, pfx := range pfxs {
-		clone = clone.DeletePersist(pfx)
+		clone, _ = clone.DeletePersist(pfx)
 
 		// test for existence
 		if ok := orig.Exists(pfx); !ok {

--- a/table.go
+++ b/table.go
@@ -418,18 +418,14 @@ func (t *Table[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, del
 	panic("unreachable")
 }
 
-// Delete removes pfx from the tree, pfx does not have to be present.
-func (t *Table[V]) Delete(pfx netip.Prefix) {
-	_, _ = t.getAndDelete(pfx)
+// Deprecated: use [Table.Delete] instead.
+func (t *Table[V]) GetAndDelete(pfx netip.Prefix) (val V, found bool) {
+	return t.Delete(pfx)
 }
 
-// GetAndDelete deletes the prefix and returns the associated payload for prefix and true,
+// Delete the prefix and returns the associated payload for prefix and true if found
 // or the zero value and false if prefix is not set in the routing table.
-func (t *Table[V]) GetAndDelete(pfx netip.Prefix) (val V, ok bool) {
-	return t.getAndDelete(pfx)
-}
-
-func (t *Table[V]) getAndDelete(pfx netip.Prefix) (val V, existed bool) {
+func (t *Table[V]) Delete(pfx netip.Prefix) (val V, found bool) {
 	if !pfx.IsValid() {
 		return
 	}
@@ -459,8 +455,8 @@ func (t *Table[V]) getAndDelete(pfx netip.Prefix) (val V, existed bool) {
 
 		if depth == maxDepth {
 			// try to delete prefix in trie node
-			val, existed = n.prefixes.DeleteAt(art.PfxToIdx(octet, lastBits))
-			if !existed {
+			val, found = n.prefixes.DeleteAt(art.PfxToIdx(octet, lastBits))
+			if !found {
 				return
 			}
 

--- a/table_test.go
+++ b/table_test.go
@@ -92,7 +92,7 @@ func TestInvalid(t *testing.T) {
 			}
 		}(testname)
 
-		_ = tbl.DeletePersist(zeroPfx)
+		_, _, _ = tbl.DeletePersist(zeroPfx)
 	})
 
 	testname = "Update"
@@ -1063,7 +1063,7 @@ func TestDeletePersist(t *testing.T) {
 		// must not panic
 		tbl := new(Table[int])
 		checkNumNodes(t, tbl, 0)
-		tbl = tbl.DeletePersist(randomPrefix(prng))
+		tbl, _, _ = tbl.DeletePersist(randomPrefix(prng))
 		checkNumNodes(t, tbl, 0)
 	})
 
@@ -1079,7 +1079,7 @@ func TestDeletePersist(t *testing.T) {
 			{"10.0.0.1", 1},
 			{"255.255.255.255", -1},
 		})
-		tbl = tbl.DeletePersist(mpp("10.0.0.0/8"))
+		tbl, _, _ = tbl.DeletePersist(mpp("10.0.0.0/8"))
 		checkNumNodes(t, tbl, 0)
 		checkRoutes(t, tbl, []tableTest{
 			{"10.0.0.1", -1},
@@ -1100,7 +1100,7 @@ func TestDeletePersist(t *testing.T) {
 			{"255.255.255.255", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("192.168.0.1/32"))
+		tbl, _, _ = tbl.DeletePersist(mpp("192.168.0.1/32"))
 		checkNumNodes(t, tbl, 0)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", -1},
@@ -1123,7 +1123,7 @@ func TestDeletePersist(t *testing.T) {
 			{"192.40.0.1", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkNumNodes(t, tbl, 1)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", 1},
@@ -1150,7 +1150,7 @@ func TestDeletePersist(t *testing.T) {
 			{"192.255.0.1", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkNumNodes(t, tbl, 2)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", 1},
@@ -1178,7 +1178,7 @@ func TestDeletePersist(t *testing.T) {
 			{"192.255.0.1", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("192.180.0.1/32"))
+		tbl, _, _ = tbl.DeletePersist(mpp("192.180.0.1/32"))
 		checkNumNodes(t, tbl, 2)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", 1},
@@ -1201,7 +1201,7 @@ func TestDeletePersist(t *testing.T) {
 			{"192.255.0.1", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("200.0.0.0/32"))
+		tbl, _, _ = tbl.DeletePersist(mpp("200.0.0.0/32"))
 		checkNumNodes(t, tbl, 1)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", 1},
@@ -1225,7 +1225,7 @@ func TestDeletePersist(t *testing.T) {
 			{"192.255.0.1", -1},
 		})
 
-		tbl = tbl.DeletePersist(mpp("192.168.0.0/22"))
+		tbl, _, _ = tbl.DeletePersist(mpp("192.168.0.0/22"))
 		checkNumNodes(t, tbl, 1)
 		checkRoutes(t, tbl, []tableTest{
 			{"192.168.0.1", 1},
@@ -1241,7 +1241,7 @@ func TestDeletePersist(t *testing.T) {
 
 		tbl.Insert(mpp("0.0.0.0/0"), 1)
 		tbl.Insert(mpp("::/0"), 1)
-		tbl = tbl.DeletePersist(mpp("0.0.0.0/0"))
+		tbl, _, _ = tbl.DeletePersist(mpp("0.0.0.0/0"))
 
 		checkNumNodes(t, tbl, 1)
 		checkRoutes(t, tbl, []tableTest{
@@ -1259,10 +1259,10 @@ func TestDeletePersist(t *testing.T) {
 		tbl.Insert(mpp("10.20.0.0/17"), 2)
 		checkNumNodes(t, tbl, 2)
 
-		tbl = tbl.DeletePersist(mpp("10.20.0.0/17"))
+		tbl, _, _ = tbl.DeletePersist(mpp("10.20.0.0/17"))
 		checkNumNodes(t, tbl, 1)
 
-		tbl = tbl.DeletePersist(mpp("10.10.0.0/17"))
+		tbl, _, _ = tbl.DeletePersist(mpp("10.10.0.0/17"))
 		checkNumNodes(t, tbl, 0)
 	})
 }
@@ -3352,7 +3352,8 @@ func TestWalkPersist(t *testing.T) {
 				"fd00::/8":   "ula",
 			},
 			fn: func(pt *Table[string], pfx netip.Prefix, val string) (*Table[string], bool) {
-				return pt.DeletePersist(pfx), true // remove everything
+				prt, _, _ := pt.DeletePersist(pfx)
+				return prt, true // remove everything
 			},
 			wantRemain: []string{},
 		},
@@ -3364,7 +3365,7 @@ func TestWalkPersist(t *testing.T) {
 			},
 			fn: func(pt *Table[string], pfx netip.Prefix, val string) (*Table[string], bool) {
 				if pfx.Addr().Is4() {
-					pt = pt.DeletePersist(pfx)
+					pt, _, _ = pt.DeletePersist(pfx)
 				}
 				return pt, true
 			},
@@ -3378,7 +3379,7 @@ func TestWalkPersist(t *testing.T) {
 			},
 			fn: func(pt *Table[string], pfx netip.Prefix, val string) (*Table[string], bool) {
 				if val == "removeMe" {
-					pt = pt.DeletePersist(pfx)
+					pt, _, _ = pt.DeletePersist(pfx)
 				}
 				return pt, true
 			},
@@ -3501,7 +3502,7 @@ func BenchmarkTableDelete(b *testing.B) {
 
 		b.Run(fmt.Sprintf("persist from_%d", n), func(b *testing.B) {
 			for b.Loop() {
-				_ = prt.DeletePersist(probe)
+				_, _, _ = prt.DeletePersist(probe)
 			}
 		})
 	}
@@ -3829,7 +3830,7 @@ func BenchmarkWalkPersist(b *testing.B) {
 		// callback: delete 1/10 of the entries
 		fn := func(pt *Table[int], pfx netip.Prefix, val int) (*Table[int], bool) {
 			if val%10 == 0 {
-				pt = pt.DeletePersist(pfx)
+				pt, _, _ = pt.DeletePersist(pfx)
 			}
 			return pt, true
 		}


### PR DESCRIPTION
Delete(pfx netip.Prefix) (val V, found bool)
DeletePersist(pfx netip.Prefix) (pt *Table[V], val V, found bool)

deprecate GetAndDelete in favour of Delete
deprecate GetAndDeletePersist in favour of DeletePersist