### PR TITLE
Add README example: simple ACL with bart.Lite for IP allowlisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Some delegated methods are pointless without a payload.
    }
 
    func (l *Lite) Exists(pfx netip.Prefix) bool
-   func (l *Lite) Contains(pfx netip.Prefix) bool
+   func (l *Lite) Contains(ip netip.Addr) bool
 
    func (l *Lite) Insert(pfx netip.Prefix)
    func (l *Lite) Delete(pfx netip.Prefix) bool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Example: simple ACL" under Usage and Compilation demonstrating building an allowlist and testing IPv4/IPv6 addresses.
  * Updated example to reflect an API change: the Lite contains-check now accepts an IP address (not a prefix) when testing authorization.
  * Clarified usage steps for access-control checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->