### PR TITLE
Devel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,28 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/" # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "gomod"]
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
-    directory: "/" # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
     schedule:
       interval: "weekly"
-
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,36 +19,43 @@ concurrency:
 jobs:
   test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         go-version: ['stable', 'oldstable']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - run: go test -v ./...
+      - run: go test -v -run='Persist' -race
+      - run: go test -v -run='Example' -race
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - id: go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ steps.go.outputs.go-version }}
+          check-latest: true
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
-      - uses: actions/checkout@v5
-      - run: go test -v ./...      
-      - run: go test -v -run='Persist' -race
-      - run: go test -v -run='Example' -race
-  
-  govulncheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: 1.24
-          check-latest: true
-      
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5         
-      - uses: actions/setup-go@v6
-        with:
-          go-version: 1.24
 
       - name: Test Coverage
         run: go test -v -coverprofile=profile.cov ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,14 +3,23 @@ on:
   push:
     branches: ["main", "devel"]
     paths:
-    - '**.go'
-    - '**.yml'
+      - '**.go'
+      - '**.yml'
+      - '**.yaml'
   pull_request:
-    branches: ["main"]  
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: ['stable', 'oldstable']
         os: [ubuntu-latest, macos-latest]
@@ -18,7 +27,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: stable
+          cache: true
       - uses: actions/checkout@v5
       - run: go test -v ./...      
       - run: go test -v -run='Persist' -race
@@ -53,8 +63,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24
-          
+          go-version: stable
+          cache: true
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gaissmai/bart
 
-go 1.24.0
+go 1.24.4
 
 retract v0.20.5 // introduced a bug in InsertPersist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Dependabot runs weekly (Mon 04:00 UTC) for modules and actions, limits open PRs to 5, adds labels and commit-message prefixes, and groups minor/patch dependency updates.

- CI
  - Unified Go version resolution via go.mod, enabled caching, added vulnerability scanning step, preserved race/example tests and disabled fail-fast, added workflow concurrency and read-only permissions, and expanded triggers to include YAML files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->