### PR TITLE
make nil ptr handling coherent

### DIFF
--- a/bartmethodsgenerated.go
+++ b/bartmethodsgenerated.go
@@ -351,7 +351,7 @@ func (t *Table[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *Table[V]) Overlaps(o *Table[V]) bool {
-	if o == nil {
+	if t == nil || o == nil {
 		return false
 	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
@@ -359,7 +359,7 @@ func (t *Table[V]) Overlaps(o *Table[V]) bool {
 
 // Overlaps4 is like [Table.Overlaps] but for the v4 routing table only.
 func (t *Table[V]) Overlaps4(o *Table[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t == nil || o == nil || t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +367,7 @@ func (t *Table[V]) Overlaps4(o *Table[V]) bool {
 
 // Overlaps6 is like [Table.Overlaps] but for the v6 routing table only.
 func (t *Table[V]) Overlaps6(o *Table[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t == nil || o == nil || t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -381,6 +381,10 @@ func (t *Table[V]) Overlaps6(o *Table[V]) bool {
 // Clone method, the value is deeply cloned before insertion. See also Table.Clone.
 func (t *Table[V]) Union(o *Table[V]) {
 	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+		return
+	}
+	if t == nil {
+		t = o.Clone()
 		return
 	}
 
@@ -401,7 +405,7 @@ func (t *Table[V]) Union(o *Table[V]) {
 // If o is nil or empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *Table[V]) UnionPersist(o *Table[V]) *Table[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if t == nil || o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
 		return t
 	}
 
@@ -453,7 +457,7 @@ func (t *Table[V]) UnionPersist(o *Table[V]) *Table[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Table[V]) Equal(o *Table[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t == nil || o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -498,16 +502,25 @@ func (t *Table[V]) Clone() *Table[V] {
 
 // Size returns the prefix count.
 func (t *Table[V]) Size() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4 + t.size6
 }
 
 // Size4 returns the IPv4 prefix count.
 func (t *Table[V]) Size4() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4
 }
 
 // Size6 returns the IPv6 prefix count.
 func (t *Table[V]) Size6() int {
+	if t == nil {
+		return 0
+	}
 	return t.size6
 }
 

--- a/barttestsgenerated_test.go
+++ b/barttestsgenerated_test.go
@@ -55,10 +55,6 @@ func TestTableNil_Table(t *testing.T) {
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
-		mustPanic(t, "Size", func() { tbl1.Size() })
-		mustPanic(t, "Size4", func() { tbl1.Size4() })
-		mustPanic(t, "Size6", func() { tbl1.Size6() })
-
 		mustPanic(t, "Get", func() { tbl1.Get(pfx4) })
 		mustPanic(t, "Insert", func() { tbl1.Insert(pfx4, nil) })
 		mustPanic(t, "InsertPersist", func() { tbl1.InsertPersist(pfx4, nil) })
@@ -70,12 +66,17 @@ func TestTableNil_Table(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
 	})
 
 	t.Run("noPanic", func(t *testing.T) {
 		t.Parallel()
+
+		noPanic(t, "Size", func() { tbl1.Size() })
+		noPanic(t, "Size4", func() { tbl1.Size4() })
+		noPanic(t, "Size6", func() { tbl1.Size6() })
 
 		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
 		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
@@ -85,15 +86,16 @@ func TestTableNil_Table(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
+		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
+		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
+		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
+
+		noPanic(t, "Union", func() { tbl1.Union(tbl2) })
+		noPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
 
 		noPanic(t, "dump", func() { tbl1.dump(nil) })
 		noPanic(t, "dumpString", func() { tbl1.dumpString() })

--- a/commonmethods_tmpl.go
+++ b/commonmethods_tmpl.go
@@ -412,7 +412,7 @@ func (t *_TABLE_TYPE[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *_TABLE_TYPE[V]) Overlaps(o *_TABLE_TYPE[V]) bool {
-	if o == nil {
+	if t == nil || o == nil {
 		return false
 	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
@@ -420,7 +420,7 @@ func (t *_TABLE_TYPE[V]) Overlaps(o *_TABLE_TYPE[V]) bool {
 
 // Overlaps4 is like [_TABLE_TYPE.Overlaps] but for the v4 routing table only.
 func (t *_TABLE_TYPE[V]) Overlaps4(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t == nil || o == nil || t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -428,7 +428,7 @@ func (t *_TABLE_TYPE[V]) Overlaps4(o *_TABLE_TYPE[V]) bool {
 
 // Overlaps6 is like [_TABLE_TYPE.Overlaps] but for the v6 routing table only.
 func (t *_TABLE_TYPE[V]) Overlaps6(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t == nil || o == nil || t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -442,6 +442,10 @@ func (t *_TABLE_TYPE[V]) Overlaps6(o *_TABLE_TYPE[V]) bool {
 // Clone method, the value is deeply cloned before insertion. See also _TABLE_TYPE.Clone.
 func (t *_TABLE_TYPE[V]) Union(o *_TABLE_TYPE[V]) {
 	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+		return
+	}
+	if t == nil {
+		t = o.Clone()
 		return
 	}
 
@@ -462,7 +466,7 @@ func (t *_TABLE_TYPE[V]) Union(o *_TABLE_TYPE[V]) {
 // If o is nil or empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *_TABLE_TYPE[V]) UnionPersist(o *_TABLE_TYPE[V]) *_TABLE_TYPE[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if t == nil || o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
 		return t
 	}
 
@@ -514,7 +518,7 @@ func (t *_TABLE_TYPE[V]) UnionPersist(o *_TABLE_TYPE[V]) *_TABLE_TYPE[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *_TABLE_TYPE[V]) Equal(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t == nil || o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -559,16 +563,25 @@ func (t *_TABLE_TYPE[V]) Clone() *_TABLE_TYPE[V] {
 
 // Size returns the prefix count.
 func (t *_TABLE_TYPE[V]) Size() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4 + t.size6
 }
 
 // Size4 returns the IPv4 prefix count.
 func (t *_TABLE_TYPE[V]) Size4() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4
 }
 
 // Size6 returns the IPv6 prefix count.
 func (t *_TABLE_TYPE[V]) Size6() int {
+	if t == nil {
+		return 0
+	}
 	return t.size6
 }
 

--- a/commontests_tmpl.go
+++ b/commontests_tmpl.go
@@ -125,10 +125,6 @@ func TestTableNil__TABLE_TYPE(t *testing.T) {
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
-		mustPanic(t, "Size", func() { tbl1.Size() })
-		mustPanic(t, "Size4", func() { tbl1.Size4() })
-		mustPanic(t, "Size6", func() { tbl1.Size6() })
-
 		mustPanic(t, "Get", func() { tbl1.Get(pfx4) })
 		mustPanic(t, "Insert", func() { tbl1.Insert(pfx4, nil) })
 		mustPanic(t, "InsertPersist", func() { tbl1.InsertPersist(pfx4, nil) })
@@ -140,12 +136,17 @@ func TestTableNil__TABLE_TYPE(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
 	})
 
 	t.Run("noPanic", func(t *testing.T) {
 		t.Parallel()
+
+		noPanic(t, "Size", func() { tbl1.Size() })
+		noPanic(t, "Size4", func() { tbl1.Size4() })
+		noPanic(t, "Size6", func() { tbl1.Size6() })
 
 		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
 		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
@@ -155,15 +156,16 @@ func TestTableNil__TABLE_TYPE(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
+		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
+		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
+		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
+
+		noPanic(t, "Union", func() { tbl1.Union(tbl2) })
+		noPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
 
 		noPanic(t, "dump", func() { tbl1.dump(nil) })
 		noPanic(t, "dumpString", func() { tbl1.dumpString() })

--- a/fastmethodsgenerated.go
+++ b/fastmethodsgenerated.go
@@ -351,7 +351,7 @@ func (t *Fast[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *Fast[V]) Overlaps(o *Fast[V]) bool {
-	if o == nil {
+	if t == nil || o == nil {
 		return false
 	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
@@ -359,7 +359,7 @@ func (t *Fast[V]) Overlaps(o *Fast[V]) bool {
 
 // Overlaps4 is like [Fast.Overlaps] but for the v4 routing table only.
 func (t *Fast[V]) Overlaps4(o *Fast[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t == nil || o == nil || t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +367,7 @@ func (t *Fast[V]) Overlaps4(o *Fast[V]) bool {
 
 // Overlaps6 is like [Fast.Overlaps] but for the v6 routing table only.
 func (t *Fast[V]) Overlaps6(o *Fast[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t == nil || o == nil || t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -381,6 +381,10 @@ func (t *Fast[V]) Overlaps6(o *Fast[V]) bool {
 // Clone method, the value is deeply cloned before insertion. See also Fast.Clone.
 func (t *Fast[V]) Union(o *Fast[V]) {
 	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+		return
+	}
+	if t == nil {
+		t = o.Clone()
 		return
 	}
 
@@ -401,7 +405,7 @@ func (t *Fast[V]) Union(o *Fast[V]) {
 // If o is nil or empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *Fast[V]) UnionPersist(o *Fast[V]) *Fast[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if t == nil || o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
 		return t
 	}
 
@@ -453,7 +457,7 @@ func (t *Fast[V]) UnionPersist(o *Fast[V]) *Fast[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Fast[V]) Equal(o *Fast[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t == nil || o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -498,16 +502,25 @@ func (t *Fast[V]) Clone() *Fast[V] {
 
 // Size returns the prefix count.
 func (t *Fast[V]) Size() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4 + t.size6
 }
 
 // Size4 returns the IPv4 prefix count.
 func (t *Fast[V]) Size4() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4
 }
 
 // Size6 returns the IPv6 prefix count.
 func (t *Fast[V]) Size6() int {
+	if t == nil {
+		return 0
+	}
 	return t.size6
 }
 

--- a/fasttestsgenerated_test.go
+++ b/fasttestsgenerated_test.go
@@ -55,10 +55,6 @@ func TestTableNil_Fast(t *testing.T) {
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
-		mustPanic(t, "Size", func() { tbl1.Size() })
-		mustPanic(t, "Size4", func() { tbl1.Size4() })
-		mustPanic(t, "Size6", func() { tbl1.Size6() })
-
 		mustPanic(t, "Get", func() { tbl1.Get(pfx4) })
 		mustPanic(t, "Insert", func() { tbl1.Insert(pfx4, nil) })
 		mustPanic(t, "InsertPersist", func() { tbl1.InsertPersist(pfx4, nil) })
@@ -70,12 +66,17 @@ func TestTableNil_Fast(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
 	})
 
 	t.Run("noPanic", func(t *testing.T) {
 		t.Parallel()
+
+		noPanic(t, "Size", func() { tbl1.Size() })
+		noPanic(t, "Size4", func() { tbl1.Size4() })
+		noPanic(t, "Size6", func() { tbl1.Size6() })
 
 		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
 		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
@@ -85,15 +86,16 @@ func TestTableNil_Fast(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
+		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
+		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
+		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
+
+		noPanic(t, "Union", func() { tbl1.Union(tbl2) })
+		noPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
 
 		noPanic(t, "dump", func() { tbl1.dump(nil) })
 		noPanic(t, "dumpString", func() { tbl1.dumpString() })

--- a/lite.go
+++ b/lite.go
@@ -215,6 +215,46 @@ func (l *Lite) UnionPersist(o *Lite) *Lite {
 	return &Lite{*lp}
 }
 
+// Size returns the prefix count.
+func (l *Lite) Size() int {
+	if l == nil {
+		return 0
+	}
+	return l.liteTable.Size()
+}
+
+// Size4 returns the IPv4 prefix count.
+func (l *Lite) Size4() int {
+	if l == nil {
+		return 0
+	}
+	return l.liteTable.Size4()
+}
+
+// Size6 returns the IPv6 prefix count.
+func (l *Lite) Size6() int {
+	if l == nil {
+		return 0
+	}
+	return l.liteTable.Size6()
+}
+
+// dump the table structure and all the nodes to w.
+func (l *Lite) dump(w io.Writer) {
+	if l == nil {
+		return
+	}
+	l.liteTable.dump(w)
+}
+
+// dumpString is just a wrapper for dump.
+func (l *Lite) dumpString() string {
+	if l == nil {
+		return ""
+	}
+	return l.liteTable.dumpString()
+}
+
 // All returns an iterator over all prefixes in the table.
 //
 // The entries from both IPv4 and IPv6 subtries are yielded using an internal recursive traversal.
@@ -367,7 +407,7 @@ func (l *Lite) Supernets(pfx netip.Prefix) iter.Seq[netip.Prefix] {
 // It is intentionally not nil-receiver safe: calling with a nil
 // receiver will panic by design.
 func (l *Lite) Overlaps(o *Lite) bool {
-	if o == nil {
+	if l == nil || o == nil {
 		return false
 	}
 	return l.liteTable.Overlaps(&o.liteTable)
@@ -375,7 +415,7 @@ func (l *Lite) Overlaps(o *Lite) bool {
 
 // Overlaps4 is like [Lite.Overlaps] but for the v4 routing table only.
 func (l *Lite) Overlaps4(o *Lite) bool {
-	if o == nil {
+	if l == nil || o == nil {
 		return false
 	}
 	return l.liteTable.Overlaps4(&o.liteTable)
@@ -383,7 +423,7 @@ func (l *Lite) Overlaps4(o *Lite) bool {
 
 // Overlaps6 is like [Lite.Overlaps] but for the v6 routing table only.
 func (l *Lite) Overlaps6(o *Lite) bool {
-	if o == nil {
+	if l == nil || o == nil {
 		return false
 	}
 	return l.liteTable.Overlaps6(&o.liteTable)
@@ -395,7 +435,7 @@ func (l *Lite) Overlaps6(o *Lite) bool {
 //
 // Note: Lite has no payload values, so this only checks structural equality.
 func (l *Lite) Equal(o *Lite) bool {
-	if o == nil || l.size4 != o.size4 || l.size6 != o.size6 {
+	if l == nil || o == nil || l.size4 != o.size4 || l.size6 != o.size6 {
 		return false
 	}
 	return l.liteTable.Equal(&o.liteTable)

--- a/lite.go
+++ b/lite.go
@@ -198,6 +198,11 @@ func (l *Lite) Union(o *Lite) {
 	if o == nil {
 		return
 	}
+	if l == nil {
+		l = o.Clone()
+		return
+	}
+
 	l.liteTable.Union(&o.liteTable)
 }
 
@@ -207,7 +212,7 @@ func (l *Lite) Union(o *Lite) {
 // If o is nil or empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (l *Lite) UnionPersist(o *Lite) *Lite {
-	if o == nil || (o.size4 == 0 && o.size6 == 0) {
+	if l == nil || o == nil || o == l || (o.size4 == 0 && o.size6 == 0) {
 		return l
 	}
 	lp := l.liteTable.UnionPersist(&o.liteTable)

--- a/litemethodsgenerated.go
+++ b/litemethodsgenerated.go
@@ -351,7 +351,7 @@ func (t *liteTable[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *liteTable[V]) Overlaps(o *liteTable[V]) bool {
-	if o == nil {
+	if t == nil || o == nil {
 		return false
 	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
@@ -359,7 +359,7 @@ func (t *liteTable[V]) Overlaps(o *liteTable[V]) bool {
 
 // Overlaps4 is like [liteTable.Overlaps] but for the v4 routing table only.
 func (t *liteTable[V]) Overlaps4(o *liteTable[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t == nil || o == nil || t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +367,7 @@ func (t *liteTable[V]) Overlaps4(o *liteTable[V]) bool {
 
 // Overlaps6 is like [liteTable.Overlaps] but for the v6 routing table only.
 func (t *liteTable[V]) Overlaps6(o *liteTable[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t == nil || o == nil || t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -381,6 +381,10 @@ func (t *liteTable[V]) Overlaps6(o *liteTable[V]) bool {
 // Clone method, the value is deeply cloned before insertion. See also liteTable.Clone.
 func (t *liteTable[V]) Union(o *liteTable[V]) {
 	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+		return
+	}
+	if t == nil {
+		t = o.Clone()
 		return
 	}
 
@@ -401,7 +405,7 @@ func (t *liteTable[V]) Union(o *liteTable[V]) {
 // If o is nil or empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *liteTable[V]) UnionPersist(o *liteTable[V]) *liteTable[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if t == nil || o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
 		return t
 	}
 
@@ -453,7 +457,7 @@ func (t *liteTable[V]) UnionPersist(o *liteTable[V]) *liteTable[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *liteTable[V]) Equal(o *liteTable[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t == nil || o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -498,16 +502,25 @@ func (t *liteTable[V]) Clone() *liteTable[V] {
 
 // Size returns the prefix count.
 func (t *liteTable[V]) Size() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4 + t.size6
 }
 
 // Size4 returns the IPv4 prefix count.
 func (t *liteTable[V]) Size4() int {
+	if t == nil {
+		return 0
+	}
 	return t.size4
 }
 
 // Size6 returns the IPv6 prefix count.
 func (t *liteTable[V]) Size6() int {
+	if t == nil {
+		return 0
+	}
 	return t.size6
 }
 

--- a/litespecial_test.go
+++ b/litespecial_test.go
@@ -33,10 +33,6 @@ func TestTableNil_LiteTable(t *testing.T) {
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
-		mustPanic(t, "Size", func() { tbl1.Size() })
-		mustPanic(t, "Size4", func() { tbl1.Size4() })
-		mustPanic(t, "Size6", func() { tbl1.Size6() })
-
 		mustPanic(t, "Get", func() { tbl1.Get(pfx4) })
 		mustPanic(t, "Insert", func() { tbl1.Insert(pfx4) })
 		mustPanic(t, "InsertPersist", func() { tbl1.InsertPersist(pfx4) })
@@ -50,10 +46,17 @@ func TestTableNil_LiteTable(t *testing.T) {
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
 		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
 		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
 	})
 
 	t.Run("noPanic", func(t *testing.T) {
 		t.Parallel()
+
+		noPanic(t, "Size", func() { tbl1.Size() })
+		noPanic(t, "Size4", func() { tbl1.Size4() })
+		noPanic(t, "Size6", func() { tbl1.Size6() })
 
 		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
 		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
@@ -63,18 +66,16 @@ func TestTableNil_LiteTable(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
+		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
+		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
+		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
 
-		mustPanic(t, "dump", func() { tbl1.dump(nil) })
-		mustPanic(t, "dumpString", func() { tbl1.dumpString() })
+		noPanic(t, "dump", func() { tbl1.dump(nil) })
+		noPanic(t, "dumpString", func() { tbl1.dumpString() })
 		noPanic(t, "Clone", func() { tbl1.Clone() })
 		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
 		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })

--- a/litespecial_test.go
+++ b/litespecial_test.go
@@ -44,8 +44,6 @@ func TestTableNil_LiteTable(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
 
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
@@ -66,12 +64,12 @@ func TestTableNil_LiteTable(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		noPanic(t, "Union", func() { tbl1.Union(tbl2) })
+		noPanic(t, "Union", func() { tbl2.Union(tbl1) })
+		noPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+		noPanic(t, "UnionPersist", func() { tbl2.UnionPersist(tbl1) })
 
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
 
 		noPanic(t, "dump", func() { tbl1.dump(nil) })

--- a/litetestsgenerated_test.go
+++ b/litetestsgenerated_test.go
@@ -55,10 +55,6 @@ func TestTableNil_liteTable(t *testing.T) {
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
 		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
-		mustPanic(t, "Size", func() { tbl1.Size() })
-		mustPanic(t, "Size4", func() { tbl1.Size4() })
-		mustPanic(t, "Size6", func() { tbl1.Size6() })
-
 		mustPanic(t, "Get", func() { tbl1.Get(pfx4) })
 		mustPanic(t, "Insert", func() { tbl1.Insert(pfx4, nil) })
 		mustPanic(t, "InsertPersist", func() { tbl1.InsertPersist(pfx4, nil) })
@@ -70,12 +66,17 @@ func TestTableNil_liteTable(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
+
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
+		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
 	})
 
 	t.Run("noPanic", func(t *testing.T) {
 		t.Parallel()
+
+		noPanic(t, "Size", func() { tbl1.Size() })
+		noPanic(t, "Size4", func() { tbl1.Size4() })
+		noPanic(t, "Size6", func() { tbl1.Size6() })
 
 		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
 		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
@@ -85,15 +86,16 @@ func TestTableNil_liteTable(t *testing.T) {
 		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
 		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
 
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
-		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		noPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
+		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
+		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
+		noPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
 		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
 		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
+
+		noPanic(t, "Union", func() { tbl1.Union(tbl2) })
+		noPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
 
 		noPanic(t, "dump", func() { tbl1.dump(nil) })
 		noPanic(t, "dumpString", func() { tbl1.dumpString() })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public methods to access prefix counts: `Size()`, `Size4()`, `Size6()` and debugging utilities `dump()`, `dumpString()` on Lite tables.

* **Bug Fixes**
  * Enhanced nil-safety across table operations: methods now gracefully handle nil receivers instead of panicking, returning safe defaults (false, 0) as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->