### PR TITLE
always panic on non nil receivers and arguments

### DIFF
--- a/bart.go
+++ b/bart.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -16,12 +16,13 @@ import (
 //
 // The zero value is ready to use.
 //
+// A Table must not be copied by value; always pass by pointer.
+// Nil pointers as receivers or arguments are forbidden and will panic.
+//
 // The Table is safe for concurrent reads, but concurrent reads and writes
 // must be externally synchronized. Mutation via Insert/Delete requires locks,
 // or alternatively, use ...Persist methods which return a modified copy
 // without altering the original table (copy-on-write).
-//
-// A Table must not be copied by value; always pass by pointer.
 //
 // Performance note: Do not pass IPv4-in-IPv6 addresses (e.g., ::ffff:192.0.2.1)
 // as input. The methods do not perform automatic unmapping to avoid unnecessary

--- a/bartmethodsgenerated.go
+++ b/bartmethodsgenerated.go
@@ -1,6 +1,6 @@
 // Code generated from file "commonmethods_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -266,9 +266,6 @@ func (t *Table[V]) ModifyPersist(pfx netip.Prefix, cb func(_ V, ok bool) (_ V, d
 // Returns an empty iterator if the prefix is invalid.
 func (t *Table[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -298,9 +295,6 @@ func (t *Table[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 // Returns an empty iterator if the prefix is invalid.
 func (t *Table[V]) Subnets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -351,15 +345,12 @@ func (t *Table[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *Table[V]) Overlaps(o *Table[V]) bool {
-	if o == nil {
-		return false
-	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
 }
 
 // Overlaps4 is like [Table.Overlaps] but for the v4 routing table only.
 func (t *Table[V]) Overlaps4(o *Table[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +358,7 @@ func (t *Table[V]) Overlaps4(o *Table[V]) bool {
 
 // Overlaps6 is like [Table.Overlaps] but for the v6 routing table only.
 func (t *Table[V]) Overlaps6(o *Table[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -380,7 +371,11 @@ func (t *Table[V]) Overlaps6(o *Table[V]) bool {
 // This duplicate is shallow-copied by default, but if the value type V implements the
 // Clone method, the value is deeply cloned before insertion. See also Table.Clone.
 func (t *Table[V]) Union(o *Table[V]) {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return
+	}
+	// t is unchanged
+	if o == t {
 		return
 	}
 
@@ -398,10 +393,13 @@ func (t *Table[V]) Union(o *Table[V]) {
 // UnionPersist is similar to [Union] but the receiver isn't modified.
 //
 // All nodes touched during union are cloned and a new *Table is returned.
-// If o is nil or empty, no nodes are touched and the receiver may be
+// If o is empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *Table[V]) UnionPersist(o *Table[V]) *Table[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return t
+	}
+	if o == t {
 		return t
 	}
 
@@ -453,7 +451,7 @@ func (t *Table[V]) UnionPersist(o *Table[V]) *Table[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Table[V]) Equal(o *Table[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -479,10 +477,6 @@ func (t *Table[V]) Equal(o *Table[V]) bool {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Table[V]) Clone() *Table[V] {
-	if t == nil {
-		return nil
-	}
-
 	c := new(Table[V])
 
 	cloneFn := value.CloneFnFactory[V]()
@@ -539,9 +533,6 @@ func (t *Table[V]) Size6() int {
 //	}
 func (t *Table[V]) All() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield) && t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -549,9 +540,6 @@ func (t *Table[V]) All() iter.Seq2[netip.Prefix, V] {
 // All4 is like [Table.All] but only for the v4 routing table.
 func (t *Table[V]) All4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield)
 	}
 }
@@ -559,9 +547,6 @@ func (t *Table[V]) All4() iter.Seq2[netip.Prefix, V] {
 // All6 is like [Table.All] but only for the v6 routing table.
 func (t *Table[V]) All6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -585,9 +570,6 @@ func (t *Table[V]) All6() iter.Seq2[netip.Prefix, V] {
 // traversal is required use persistent table methods.
 func (t *Table[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield) &&
 			t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
@@ -596,9 +578,6 @@ func (t *Table[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 // AllSorted4 is like [Table.AllSorted] but only for the v4 routing table.
 func (t *Table[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield)
 	}
 }
@@ -606,9 +585,6 @@ func (t *Table[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 // AllSorted6 is like [Table.AllSorted] but only for the v6 routing table.
 func (t *Table[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
 }
@@ -636,11 +612,8 @@ func (t *Table[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 //	   │  └─ 2001:db8::/32 (V)
 //	   └─ fe80::/10 (V)
 func (t *Table[V]) Fprint(w io.Writer) error {
-	if w == nil {
+	if w == nil && t != nil {
 		return fmt.Errorf("nil writer")
-	}
-	if t == nil {
-		return nil
 	}
 
 	// v4
@@ -691,10 +664,6 @@ func (t *Table[V]) MarshalText() ([]byte, error) {
 // MarshalJSON dumps the table into two sorted lists: for ipv4 and ipv6.
 // Every root and subnet is an array, not a map, because the order matters.
 func (t *Table[V]) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-
 	result := struct {
 		Ipv4 []DumpListNode[V] `json:"ipv4,omitempty"`
 		Ipv6 []DumpListNode[V] `json:"ipv6,omitempty"`
@@ -714,18 +683,12 @@ func (t *Table[V]) MarshalJSON() ([]byte, error) {
 // DumpList4 dumps the ipv4 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build the text or JSON serialization.
 func (t *Table[V]) DumpList4() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root4, 0, stridePath{}, 0, true)
 }
 
 // DumpList6 dumps the ipv6 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build custom JSON representation.
 func (t *Table[V]) DumpList6() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root6, 0, stridePath{}, 0, false)
 }
 
@@ -775,10 +738,6 @@ func (t *Table[V]) dumpString() string {
 
 // dump the table structure and all the nodes to w.
 func (t *Table[V]) dump(w io.Writer) {
-	if t == nil {
-		return
-	}
-
 	if t.size4 > 0 {
 		stats := t.root4.StatsRec()
 		fmt.Fprintln(w)

--- a/barttestsgenerated_test.go
+++ b/barttestsgenerated_test.go
@@ -1,6 +1,6 @@
 // Code generated from file "commontests_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -30,7 +30,7 @@ func (t *Table[V]) flatSorted() golden.Table[V] {
 	return flat
 }
 
-func TestTableNil_Table(t *testing.T) {
+func TestTableNilReceiver_Table(t *testing.T) {
 	t.Parallel()
 
 	ip4 := mpa("127.0.0.1")
@@ -39,21 +39,10 @@ func TestTableNil_Table(t *testing.T) {
 	pfx4 := mpp("127.0.0.0/8")
 	pfx6 := mpp("::1/128")
 
-	tbl2 := new(Table[any])
-	tbl2.Insert(pfx4, nil)
-	tbl2.Insert(pfx6, nil)
-
 	var tbl1 *Table[any] = nil
 
 	t.Run("mustPanic", func(t *testing.T) {
 		t.Parallel()
-
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(true, 1) })
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(false, 1) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(true) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(false) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
 		mustPanic(t, "Size", func() { tbl1.Size() })
 		mustPanic(t, "Size4", func() { tbl1.Size4() })
@@ -70,52 +59,29 @@ func TestTableNil_Table(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
-	})
-
-	t.Run("noPanic", func(t *testing.T) {
-		t.Parallel()
-
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
-
-		noPanic(t, "Overlaps", func() { tbl2.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
-
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		mustPanic(t, "Clone", func() { tbl1.Clone() })
+		mustPanic(t, "Union", func() { tbl1.Union(nil) })
+		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(nil) })
+		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
+		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
+		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		mustPanic(t, "Equal", func() { tbl1.Equal(nil) })
+		mustPanic(t, "DumpList4", func() { tbl1.DumpList4() })
+		mustPanic(t, "DumpList6", func() { tbl1.DumpList6() })
+		mustPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
+		mustPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
+		mustPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
-		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
-
-		noPanic(t, "dump", func() { tbl1.dump(nil) })
-		noPanic(t, "dumpString", func() { tbl1.dumpString() })
-		noPanic(t, "Clone", func() { tbl1.Clone() })
-		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
-		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })
-		noPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
-		noPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
-		noPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
-	})
-
-	t.Run("noPanicRangeOverFunc", func(t *testing.T) {
-		t.Parallel()
-
-		noPanicRangeOverFunc[any](t, "All", tbl1.All)
-		noPanicRangeOverFunc[any](t, "All4", tbl1.All4)
-		noPanicRangeOverFunc[any](t, "All6", tbl1.All6)
-		noPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
-		noPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
-		noPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
-		noPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
-		noPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
+		mustPanicRangeOverFunc[any](t, "All", tbl1.All)
+		mustPanicRangeOverFunc[any](t, "All4", tbl1.All4)
+		mustPanicRangeOverFunc[any](t, "All6", tbl1.All6)
+		mustPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
+		mustPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
+		mustPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
+		mustPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
+		mustPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
 	})
 }
 
@@ -1302,12 +1268,7 @@ func TestTableClone_Table(t *testing.T) {
 	prng := rand.New(rand.NewPCG(42, 42))
 	pfxs := random.RealWorldPrefixes(prng, n)
 
-	var tbl *Table[int]
-	if tbl.Clone() != nil {
-		t.Fatal("expected nil")
-	}
-
-	tbl = new(Table[int])
+	tbl := new(Table[int])
 	for i, pfx := range pfxs {
 		tbl.Insert(pfx, i)
 	}

--- a/commonmethods_tmpl.go
+++ b/commonmethods_tmpl.go
@@ -1,6 +1,6 @@
 //go:build generate
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 //go:generate ./scripts/generate-table-methods.sh
@@ -327,9 +327,6 @@ func (t *_TABLE_TYPE[V]) ModifyPersist(pfx netip.Prefix, cb func(_ V, ok bool) (
 // Returns an empty iterator if the prefix is invalid.
 func (t *_TABLE_TYPE[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -359,9 +356,6 @@ func (t *_TABLE_TYPE[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] 
 // Returns an empty iterator if the prefix is invalid.
 func (t *_TABLE_TYPE[V]) Subnets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -412,15 +406,12 @@ func (t *_TABLE_TYPE[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *_TABLE_TYPE[V]) Overlaps(o *_TABLE_TYPE[V]) bool {
-	if o == nil {
-		return false
-	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
 }
 
 // Overlaps4 is like [_TABLE_TYPE.Overlaps] but for the v4 routing table only.
 func (t *_TABLE_TYPE[V]) Overlaps4(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -428,7 +419,7 @@ func (t *_TABLE_TYPE[V]) Overlaps4(o *_TABLE_TYPE[V]) bool {
 
 // Overlaps6 is like [_TABLE_TYPE.Overlaps] but for the v6 routing table only.
 func (t *_TABLE_TYPE[V]) Overlaps6(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -441,7 +432,11 @@ func (t *_TABLE_TYPE[V]) Overlaps6(o *_TABLE_TYPE[V]) bool {
 // This duplicate is shallow-copied by default, but if the value type V implements the
 // Clone method, the value is deeply cloned before insertion. See also _TABLE_TYPE.Clone.
 func (t *_TABLE_TYPE[V]) Union(o *_TABLE_TYPE[V]) {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return
+	}
+	// t is unchanged
+	if o == t {
 		return
 	}
 
@@ -459,10 +454,13 @@ func (t *_TABLE_TYPE[V]) Union(o *_TABLE_TYPE[V]) {
 // UnionPersist is similar to [Union] but the receiver isn't modified.
 //
 // All nodes touched during union are cloned and a new *_TABLE_TYPE is returned.
-// If o is nil or empty, no nodes are touched and the receiver may be
+// If o is empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *_TABLE_TYPE[V]) UnionPersist(o *_TABLE_TYPE[V]) *_TABLE_TYPE[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return t
+	}
+	if o == t {
 		return t
 	}
 
@@ -514,7 +512,7 @@ func (t *_TABLE_TYPE[V]) UnionPersist(o *_TABLE_TYPE[V]) *_TABLE_TYPE[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *_TABLE_TYPE[V]) Equal(o *_TABLE_TYPE[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -540,10 +538,6 @@ func (t *_TABLE_TYPE[V]) Equal(o *_TABLE_TYPE[V]) bool {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *_TABLE_TYPE[V]) Clone() *_TABLE_TYPE[V] {
-	if t == nil {
-		return nil
-	}
-
 	c := new(_TABLE_TYPE[V])
 
 	cloneFn := value.CloneFnFactory[V]()
@@ -600,9 +594,6 @@ func (t *_TABLE_TYPE[V]) Size6() int {
 //	}
 func (t *_TABLE_TYPE[V]) All() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield) && t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -610,9 +601,6 @@ func (t *_TABLE_TYPE[V]) All() iter.Seq2[netip.Prefix, V] {
 // All4 is like [_TABLE_TYPE.All] but only for the v4 routing table.
 func (t *_TABLE_TYPE[V]) All4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield)
 	}
 }
@@ -620,9 +608,6 @@ func (t *_TABLE_TYPE[V]) All4() iter.Seq2[netip.Prefix, V] {
 // All6 is like [_TABLE_TYPE.All] but only for the v6 routing table.
 func (t *_TABLE_TYPE[V]) All6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -646,9 +631,6 @@ func (t *_TABLE_TYPE[V]) All6() iter.Seq2[netip.Prefix, V] {
 // traversal is required use persistent table methods.
 func (t *_TABLE_TYPE[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield) &&
 			t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
@@ -657,9 +639,6 @@ func (t *_TABLE_TYPE[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 // AllSorted4 is like [_TABLE_TYPE.AllSorted] but only for the v4 routing table.
 func (t *_TABLE_TYPE[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield)
 	}
 }
@@ -667,9 +646,6 @@ func (t *_TABLE_TYPE[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 // AllSorted6 is like [_TABLE_TYPE.AllSorted] but only for the v6 routing table.
 func (t *_TABLE_TYPE[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
 }
@@ -697,11 +673,8 @@ func (t *_TABLE_TYPE[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 //	   │  └─ 2001:db8::/32 (V)
 //	   └─ fe80::/10 (V)
 func (t *_TABLE_TYPE[V]) Fprint(w io.Writer) error {
-	if w == nil {
+	if w == nil && t != nil {
 		return fmt.Errorf("nil writer")
-	}
-	if t == nil {
-		return nil
 	}
 
 	// v4
@@ -752,10 +725,6 @@ func (t *_TABLE_TYPE[V]) MarshalText() ([]byte, error) {
 // MarshalJSON dumps the table into two sorted lists: for ipv4 and ipv6.
 // Every root and subnet is an array, not a map, because the order matters.
 func (t *_TABLE_TYPE[V]) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-
 	result := struct {
 		Ipv4 []DumpListNode[V] `json:"ipv4,omitempty"`
 		Ipv6 []DumpListNode[V] `json:"ipv6,omitempty"`
@@ -775,18 +744,12 @@ func (t *_TABLE_TYPE[V]) MarshalJSON() ([]byte, error) {
 // DumpList4 dumps the ipv4 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build the text or JSON serialization.
 func (t *_TABLE_TYPE[V]) DumpList4() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root4, 0, stridePath{}, 0, true)
 }
 
 // DumpList6 dumps the ipv6 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build custom JSON representation.
 func (t *_TABLE_TYPE[V]) DumpList6() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root6, 0, stridePath{}, 0, false)
 }
 
@@ -836,10 +799,6 @@ func (t *_TABLE_TYPE[V]) dumpString() string {
 
 // dump the table structure and all the nodes to w.
 func (t *_TABLE_TYPE[V]) dump(w io.Writer) {
-	if t == nil {
-		return
-	}
-
 	if t.size4 > 0 {
 		stats := t.root4.StatsRec()
 		fmt.Fprintln(w)

--- a/commontests_tmpl.go
+++ b/commontests_tmpl.go
@@ -1,6 +1,6 @@
 //go:build generate
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 //go:generate ./scripts/generate-table-tests.sh
@@ -100,7 +100,7 @@ func (t *_TABLE_TYPE[V]) flatSorted() golden.Table[V] {
 	return flat
 }
 
-func TestTableNil__TABLE_TYPE(t *testing.T) {
+func TestTableNilReceiver__TABLE_TYPE(t *testing.T) {
 	t.Parallel()
 
 	ip4 := mpa("127.0.0.1")
@@ -109,21 +109,10 @@ func TestTableNil__TABLE_TYPE(t *testing.T) {
 	pfx4 := mpp("127.0.0.0/8")
 	pfx6 := mpp("::1/128")
 
-	tbl2 := new(_TABLE_TYPE[any])
-	tbl2.Insert(pfx4, nil)
-	tbl2.Insert(pfx6, nil)
-
 	var tbl1 *_TABLE_TYPE[any] = nil
 
 	t.Run("mustPanic", func(t *testing.T) {
 		t.Parallel()
-
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(true, 1) })
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(false, 1) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(true) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(false) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
 		mustPanic(t, "Size", func() { tbl1.Size() })
 		mustPanic(t, "Size4", func() { tbl1.Size4() })
@@ -140,52 +129,29 @@ func TestTableNil__TABLE_TYPE(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
-	})
-
-	t.Run("noPanic", func(t *testing.T) {
-		t.Parallel()
-
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
-
-		noPanic(t, "Overlaps", func() { tbl2.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
-
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		mustPanic(t, "Clone", func() { tbl1.Clone() })
+		mustPanic(t, "Union", func() { tbl1.Union(nil) })
+		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(nil) })
+		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
+		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
+		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		mustPanic(t, "Equal", func() { tbl1.Equal(nil) })
+		mustPanic(t, "DumpList4", func() { tbl1.DumpList4() })
+		mustPanic(t, "DumpList6", func() { tbl1.DumpList6() })
+		mustPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
+		mustPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
+		mustPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
-		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
-
-		noPanic(t, "dump", func() { tbl1.dump(nil) })
-		noPanic(t, "dumpString", func() { tbl1.dumpString() })
-		noPanic(t, "Clone", func() { tbl1.Clone() })
-		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
-		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })
-		noPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
-		noPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
-		noPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
-	})
-
-	t.Run("noPanicRangeOverFunc", func(t *testing.T) {
-		t.Parallel()
-
-		noPanicRangeOverFunc[any](t, "All", tbl1.All)
-		noPanicRangeOverFunc[any](t, "All4", tbl1.All4)
-		noPanicRangeOverFunc[any](t, "All6", tbl1.All6)
-		noPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
-		noPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
-		noPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
-		noPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
-		noPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
+		mustPanicRangeOverFunc[any](t, "All", tbl1.All)
+		mustPanicRangeOverFunc[any](t, "All4", tbl1.All4)
+		mustPanicRangeOverFunc[any](t, "All6", tbl1.All6)
+		mustPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
+		mustPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
+		mustPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
+		mustPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
+		mustPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
 	})
 }
 
@@ -1372,12 +1338,7 @@ func TestTableClone__TABLE_TYPE(t *testing.T) {
 	prng := rand.New(rand.NewPCG(42, 42))
 	pfxs := random.RealWorldPrefixes(prng, n)
 
-	var tbl *_TABLE_TYPE[int]
-	if tbl.Clone() != nil {
-		t.Fatal("expected nil")
-	}
-
-	tbl = new(_TABLE_TYPE[int])
+	tbl := new(_TABLE_TYPE[int])
 	for i, pfx := range pfxs {
 		tbl.Insert(pfx, i)
 	}

--- a/fast.go
+++ b/fast.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -19,7 +19,9 @@ import (
 // speed.
 //
 // The zero value is ready to use.
+//
 // A Fast table must not be copied by value; always pass by pointer.
+// Nil pointers as receivers or arguments are forbidden and will panic.
 //
 // The payload type MUST NOT be a zero-sized value (for example: struct{}
 // or [0]byte). According to the Go specification:

--- a/fastmethodsgenerated.go
+++ b/fastmethodsgenerated.go
@@ -1,6 +1,6 @@
 // Code generated from file "commonmethods_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -266,9 +266,6 @@ func (t *Fast[V]) ModifyPersist(pfx netip.Prefix, cb func(_ V, ok bool) (_ V, de
 // Returns an empty iterator if the prefix is invalid.
 func (t *Fast[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -298,9 +295,6 @@ func (t *Fast[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 // Returns an empty iterator if the prefix is invalid.
 func (t *Fast[V]) Subnets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -351,15 +345,12 @@ func (t *Fast[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *Fast[V]) Overlaps(o *Fast[V]) bool {
-	if o == nil {
-		return false
-	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
 }
 
 // Overlaps4 is like [Fast.Overlaps] but for the v4 routing table only.
 func (t *Fast[V]) Overlaps4(o *Fast[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +358,7 @@ func (t *Fast[V]) Overlaps4(o *Fast[V]) bool {
 
 // Overlaps6 is like [Fast.Overlaps] but for the v6 routing table only.
 func (t *Fast[V]) Overlaps6(o *Fast[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -380,7 +371,11 @@ func (t *Fast[V]) Overlaps6(o *Fast[V]) bool {
 // This duplicate is shallow-copied by default, but if the value type V implements the
 // Clone method, the value is deeply cloned before insertion. See also Fast.Clone.
 func (t *Fast[V]) Union(o *Fast[V]) {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return
+	}
+	// t is unchanged
+	if o == t {
 		return
 	}
 
@@ -398,10 +393,13 @@ func (t *Fast[V]) Union(o *Fast[V]) {
 // UnionPersist is similar to [Union] but the receiver isn't modified.
 //
 // All nodes touched during union are cloned and a new *Fast is returned.
-// If o is nil or empty, no nodes are touched and the receiver may be
+// If o is empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *Fast[V]) UnionPersist(o *Fast[V]) *Fast[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return t
+	}
+	if o == t {
 		return t
 	}
 
@@ -453,7 +451,7 @@ func (t *Fast[V]) UnionPersist(o *Fast[V]) *Fast[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Fast[V]) Equal(o *Fast[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -479,10 +477,6 @@ func (t *Fast[V]) Equal(o *Fast[V]) bool {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *Fast[V]) Clone() *Fast[V] {
-	if t == nil {
-		return nil
-	}
-
 	c := new(Fast[V])
 
 	cloneFn := value.CloneFnFactory[V]()
@@ -539,9 +533,6 @@ func (t *Fast[V]) Size6() int {
 //	}
 func (t *Fast[V]) All() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield) && t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -549,9 +540,6 @@ func (t *Fast[V]) All() iter.Seq2[netip.Prefix, V] {
 // All4 is like [Fast.All] but only for the v4 routing table.
 func (t *Fast[V]) All4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield)
 	}
 }
@@ -559,9 +547,6 @@ func (t *Fast[V]) All4() iter.Seq2[netip.Prefix, V] {
 // All6 is like [Fast.All] but only for the v6 routing table.
 func (t *Fast[V]) All6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -585,9 +570,6 @@ func (t *Fast[V]) All6() iter.Seq2[netip.Prefix, V] {
 // traversal is required use persistent table methods.
 func (t *Fast[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield) &&
 			t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
@@ -596,9 +578,6 @@ func (t *Fast[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 // AllSorted4 is like [Fast.AllSorted] but only for the v4 routing table.
 func (t *Fast[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield)
 	}
 }
@@ -606,9 +585,6 @@ func (t *Fast[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 // AllSorted6 is like [Fast.AllSorted] but only for the v6 routing table.
 func (t *Fast[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
 }
@@ -636,11 +612,8 @@ func (t *Fast[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 //	   │  └─ 2001:db8::/32 (V)
 //	   └─ fe80::/10 (V)
 func (t *Fast[V]) Fprint(w io.Writer) error {
-	if w == nil {
+	if w == nil && t != nil {
 		return fmt.Errorf("nil writer")
-	}
-	if t == nil {
-		return nil
 	}
 
 	// v4
@@ -691,10 +664,6 @@ func (t *Fast[V]) MarshalText() ([]byte, error) {
 // MarshalJSON dumps the table into two sorted lists: for ipv4 and ipv6.
 // Every root and subnet is an array, not a map, because the order matters.
 func (t *Fast[V]) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-
 	result := struct {
 		Ipv4 []DumpListNode[V] `json:"ipv4,omitempty"`
 		Ipv6 []DumpListNode[V] `json:"ipv6,omitempty"`
@@ -714,18 +683,12 @@ func (t *Fast[V]) MarshalJSON() ([]byte, error) {
 // DumpList4 dumps the ipv4 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build the text or JSON serialization.
 func (t *Fast[V]) DumpList4() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root4, 0, stridePath{}, 0, true)
 }
 
 // DumpList6 dumps the ipv6 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build custom JSON representation.
 func (t *Fast[V]) DumpList6() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root6, 0, stridePath{}, 0, false)
 }
 
@@ -775,10 +738,6 @@ func (t *Fast[V]) dumpString() string {
 
 // dump the table structure and all the nodes to w.
 func (t *Fast[V]) dump(w io.Writer) {
-	if t == nil {
-		return
-	}
-
 	if t.size4 > 0 {
 		stats := t.root4.StatsRec()
 		fmt.Fprintln(w)

--- a/fasttestsgenerated_test.go
+++ b/fasttestsgenerated_test.go
@@ -1,6 +1,6 @@
 // Code generated from file "commontests_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -30,7 +30,7 @@ func (t *Fast[V]) flatSorted() golden.Table[V] {
 	return flat
 }
 
-func TestTableNil_Fast(t *testing.T) {
+func TestTableNilReceiver_Fast(t *testing.T) {
 	t.Parallel()
 
 	ip4 := mpa("127.0.0.1")
@@ -39,21 +39,10 @@ func TestTableNil_Fast(t *testing.T) {
 	pfx4 := mpp("127.0.0.0/8")
 	pfx6 := mpp("::1/128")
 
-	tbl2 := new(Fast[any])
-	tbl2.Insert(pfx4, nil)
-	tbl2.Insert(pfx6, nil)
-
 	var tbl1 *Fast[any] = nil
 
 	t.Run("mustPanic", func(t *testing.T) {
 		t.Parallel()
-
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(true, 1) })
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(false, 1) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(true) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(false) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
 		mustPanic(t, "Size", func() { tbl1.Size() })
 		mustPanic(t, "Size4", func() { tbl1.Size4() })
@@ -70,52 +59,29 @@ func TestTableNil_Fast(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
-	})
-
-	t.Run("noPanic", func(t *testing.T) {
-		t.Parallel()
-
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
-
-		noPanic(t, "Overlaps", func() { tbl2.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
-
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		mustPanic(t, "Clone", func() { tbl1.Clone() })
+		mustPanic(t, "Union", func() { tbl1.Union(nil) })
+		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(nil) })
+		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
+		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
+		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		mustPanic(t, "Equal", func() { tbl1.Equal(nil) })
+		mustPanic(t, "DumpList4", func() { tbl1.DumpList4() })
+		mustPanic(t, "DumpList6", func() { tbl1.DumpList6() })
+		mustPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
+		mustPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
+		mustPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
-		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
-
-		noPanic(t, "dump", func() { tbl1.dump(nil) })
-		noPanic(t, "dumpString", func() { tbl1.dumpString() })
-		noPanic(t, "Clone", func() { tbl1.Clone() })
-		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
-		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })
-		noPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
-		noPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
-		noPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
-	})
-
-	t.Run("noPanicRangeOverFunc", func(t *testing.T) {
-		t.Parallel()
-
-		noPanicRangeOverFunc[any](t, "All", tbl1.All)
-		noPanicRangeOverFunc[any](t, "All4", tbl1.All4)
-		noPanicRangeOverFunc[any](t, "All6", tbl1.All6)
-		noPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
-		noPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
-		noPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
-		noPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
-		noPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
+		mustPanicRangeOverFunc[any](t, "All", tbl1.All)
+		mustPanicRangeOverFunc[any](t, "All4", tbl1.All4)
+		mustPanicRangeOverFunc[any](t, "All6", tbl1.All6)
+		mustPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
+		mustPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
+		mustPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
+		mustPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
+		mustPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
 	})
 }
 
@@ -1302,12 +1268,7 @@ func TestTableClone_Fast(t *testing.T) {
 	prng := rand.New(rand.NewPCG(42, 42))
 	pfxs := random.RealWorldPrefixes(prng, n)
 
-	var tbl *Fast[int]
-	if tbl.Clone() != nil {
-		t.Fatal("expected nil")
-	}
-
-	tbl = new(Fast[int])
+	tbl := new(Fast[int])
 	for i, pfx := range pfxs {
 		tbl.Insert(pfx, i)
 	}

--- a/lite.go
+++ b/lite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -21,6 +21,7 @@ import (
 // The zero value is ready to use.
 //
 // A Lite table must not be copied by value; always pass by pointer.
+// Nil pointers as receivers or arguments are forbidden and will panic.
 //
 // Performance note: Do not pass IPv4-in-IPv6 addresses (e.g., ::ffff:192.0.2.1)
 // as input. The methods do not perform automatic unmapping to avoid unnecessary
@@ -185,9 +186,6 @@ func dropSeq2[V any](seq2 iter.Seq2[netip.Prefix, V]) iter.Seq[netip.Prefix] {
 
 // Clone returns a copy of the routing table.
 func (l *Lite) Clone() *Lite {
-	if l == nil {
-		return nil
-	}
 	return &Lite{*l.liteTable.Clone()}
 }
 
@@ -195,22 +193,19 @@ func (l *Lite) Clone() *Lite {
 //
 // All prefixes from the other table (o) are inserted into the receiver.
 func (l *Lite) Union(o *Lite) {
-	if o == nil {
-		return
-	}
 	l.liteTable.Union(&o.liteTable)
 }
 
 // UnionPersist is similar to [Union] but the receiver isn't modified.
 //
 // All nodes touched during union are cloned and a new *Lite is returned.
-// If o is nil or empty, no nodes are touched and the receiver may be
+// If o is empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (l *Lite) UnionPersist(o *Lite) *Lite {
-	if o == nil || (o.size4 == 0 && o.size6 == 0) {
+	lp := l.liteTable.UnionPersist(&o.liteTable)
+	if lp == &l.liteTable {
 		return l
 	}
-	lp := l.liteTable.UnionPersist(&o.liteTable)
 	//nolint:govet // copy of *lp is here by intention
 	return &Lite{*lp}
 }
@@ -242,25 +237,16 @@ func (l *Lite) UnionPersist(o *Lite) *Lite {
 // 	}
 
 func (l *Lite) All() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.All())
 }
 
 // All4 is like [Lite.All] but only for the v4 routing table.
 func (l *Lite) All4() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.All4())
 }
 
 // All6 is like [Lite.All] but only for the v6 routing table.
 func (l *Lite) All6() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.All6())
 }
 
@@ -282,25 +268,16 @@ func (l *Lite) All6() iter.Seq[netip.Prefix] {
 // prematurely terminate the iteration. If mutation of the table during
 // traversal is required use persistent table methods.
 func (l *Lite) AllSorted() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.AllSorted())
 }
 
 // AllSorted4 is like [Lite.AllSorted] but only for the v4 routing table.
 func (l *Lite) AllSorted4() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.AllSorted4())
 }
 
 // AllSorted6 is like [Lite.AllSorted] but only for the v6 routing table.
 func (l *Lite) AllSorted6() iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.AllSorted6())
 }
 
@@ -318,9 +295,6 @@ func (l *Lite) AllSorted6() iter.Seq[netip.Prefix] {
 // The iteration can be stopped early by breaking from the range loop.
 // Returns an empty iterator if the prefix is invalid.
 func (l *Lite) Subnets(pfx netip.Prefix) iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.Subnets(pfx))
 }
 
@@ -345,9 +319,6 @@ func (l *Lite) Subnets(pfx netip.Prefix) iter.Seq[netip.Prefix] {
 //	    fmt.Println("Matched covering route:", supernet)
 //	}
 func (l *Lite) Supernets(pfx netip.Prefix) iter.Seq[netip.Prefix] {
-	if l == nil {
-		return func(func(netip.Prefix) bool) {}
-	}
 	return dropSeq2(l.liteTable.Supernets(pfx))
 }
 
@@ -367,25 +338,16 @@ func (l *Lite) Supernets(pfx netip.Prefix) iter.Seq[netip.Prefix] {
 // It is intentionally not nil-receiver safe: calling with a nil
 // receiver will panic by design.
 func (l *Lite) Overlaps(o *Lite) bool {
-	if o == nil {
-		return false
-	}
 	return l.liteTable.Overlaps(&o.liteTable)
 }
 
 // Overlaps4 is like [Lite.Overlaps] but for the v4 routing table only.
 func (l *Lite) Overlaps4(o *Lite) bool {
-	if o == nil {
-		return false
-	}
 	return l.liteTable.Overlaps4(&o.liteTable)
 }
 
 // Overlaps6 is like [Lite.Overlaps] but for the v6 routing table only.
 func (l *Lite) Overlaps6(o *Lite) bool {
-	if o == nil {
-		return false
-	}
 	return l.liteTable.Overlaps6(&o.liteTable)
 }
 
@@ -395,27 +357,18 @@ func (l *Lite) Overlaps6(o *Lite) bool {
 //
 // Note: Lite has no payload values, so this only checks structural equality.
 func (l *Lite) Equal(o *Lite) bool {
-	if o == nil || l.size4 != o.size4 || l.size6 != o.size6 {
-		return false
-	}
 	return l.liteTable.Equal(&o.liteTable)
 }
 
 // DumpList4 dumps the ipv4 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build the text or JSON serialization.
 func (l *Lite) DumpList4() []DumpListNode[struct{}] {
-	if l == nil {
-		return nil
-	}
 	return l.liteTable.DumpList4()
 }
 
 // DumpList6 dumps the ipv6 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build custom JSON representation.
 func (l *Lite) DumpList6() []DumpListNode[struct{}] {
-	if l == nil {
-		return nil
-	}
 	return l.liteTable.DumpList6()
 }
 
@@ -442,27 +395,18 @@ func (l *Lite) DumpList6() []DumpListNode[struct{}] {
 //	   │  └─ 2001:db8::/32 (V)
 //	   └─ fe80::/10 (V)
 func (l *Lite) Fprint(w io.Writer) error {
-	if l == nil {
-		return nil
-	}
 	return l.liteTable.Fprint(w)
 }
 
 // MarshalJSON dumps the table into two sorted lists: for ipv4 and ipv6.
 // Every root and subnet is an array, not a map, because the order matters.
 func (l *Lite) MarshalJSON() ([]byte, error) {
-	if l == nil {
-		return []byte("null"), nil
-	}
 	return l.liteTable.MarshalJSON()
 }
 
 // MarshalText implements the [encoding.TextMarshaler] interface,
 // just a wrapper for [liteTable.Fprint].
 func (l *Lite) MarshalText() ([]byte, error) {
-	if l == nil {
-		return []byte{}, nil
-	}
 	return l.liteTable.MarshalText()
 }
 

--- a/litemethodsgenerated.go
+++ b/litemethodsgenerated.go
@@ -1,6 +1,6 @@
 // Code generated from file "commonmethods_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -266,9 +266,6 @@ func (t *liteTable[V]) ModifyPersist(pfx netip.Prefix, cb func(_ V, ok bool) (_ 
 // Returns an empty iterator if the prefix is invalid.
 func (t *liteTable[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -298,9 +295,6 @@ func (t *liteTable[V]) Supernets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 // Returns an empty iterator if the prefix is invalid.
 func (t *liteTable[V]) Subnets(pfx netip.Prefix) iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		if !pfx.IsValid() {
 			return
 		}
@@ -351,15 +345,12 @@ func (t *liteTable[V]) OverlapsPrefix(pfx netip.Prefix) bool {
 // This is useful for conflict detection, policy enforcement,
 // or validating mutually exclusive routing domains.
 func (t *liteTable[V]) Overlaps(o *liteTable[V]) bool {
-	if o == nil {
-		return false
-	}
 	return t.Overlaps4(o) || t.Overlaps6(o)
 }
 
 // Overlaps4 is like [liteTable.Overlaps] but for the v4 routing table only.
 func (t *liteTable[V]) Overlaps4(o *liteTable[V]) bool {
-	if o == nil || t.size4 == 0 || o.size4 == 0 {
+	if t.size4 == 0 || o.size4 == 0 {
 		return false
 	}
 	return t.root4.Overlaps(&o.root4, 0)
@@ -367,7 +358,7 @@ func (t *liteTable[V]) Overlaps4(o *liteTable[V]) bool {
 
 // Overlaps6 is like [liteTable.Overlaps] but for the v6 routing table only.
 func (t *liteTable[V]) Overlaps6(o *liteTable[V]) bool {
-	if o == nil || t.size6 == 0 || o.size6 == 0 {
+	if t.size6 == 0 || o.size6 == 0 {
 		return false
 	}
 	return t.root6.Overlaps(&o.root6, 0)
@@ -380,7 +371,11 @@ func (t *liteTable[V]) Overlaps6(o *liteTable[V]) bool {
 // This duplicate is shallow-copied by default, but if the value type V implements the
 // Clone method, the value is deeply cloned before insertion. See also liteTable.Clone.
 func (t *liteTable[V]) Union(o *liteTable[V]) {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return
+	}
+	// t is unchanged
+	if o == t {
 		return
 	}
 
@@ -398,10 +393,13 @@ func (t *liteTable[V]) Union(o *liteTable[V]) {
 // UnionPersist is similar to [Union] but the receiver isn't modified.
 //
 // All nodes touched during union are cloned and a new *liteTable is returned.
-// If o is nil or empty, no nodes are touched and the receiver may be
+// If o is empty, no nodes are touched and the receiver may be
 // returned unchanged.
 func (t *liteTable[V]) UnionPersist(o *liteTable[V]) *liteTable[V] {
-	if o == nil || o == t || (o.size4 == 0 && o.size6 == 0) {
+	if o.size4 == 0 && o.size6 == 0 {
+		return t
+	}
+	if o == t {
 		return t
 	}
 
@@ -453,7 +451,7 @@ func (t *liteTable[V]) UnionPersist(o *liteTable[V]) *liteTable[V] {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *liteTable[V]) Equal(o *liteTable[V]) bool {
-	if o == nil || t.size4 != o.size4 || t.size6 != o.size6 {
+	if t.size4 != o.size4 || t.size6 != o.size6 {
 		return false
 	}
 	if o == t {
@@ -479,10 +477,6 @@ func (t *liteTable[V]) Equal(o *liteTable[V]) bool {
 // The bart package will automatically detect and use this method via Go's
 // structural typing.
 func (t *liteTable[V]) Clone() *liteTable[V] {
-	if t == nil {
-		return nil
-	}
-
 	c := new(liteTable[V])
 
 	cloneFn := value.CloneFnFactory[V]()
@@ -539,9 +533,6 @@ func (t *liteTable[V]) Size6() int {
 //	}
 func (t *liteTable[V]) All() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield) && t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -549,9 +540,6 @@ func (t *liteTable[V]) All() iter.Seq2[netip.Prefix, V] {
 // All4 is like [liteTable.All] but only for the v4 routing table.
 func (t *liteTable[V]) All4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRec(stridePath{}, 0, true, yield)
 	}
 }
@@ -559,9 +547,6 @@ func (t *liteTable[V]) All4() iter.Seq2[netip.Prefix, V] {
 // All6 is like [liteTable.All] but only for the v6 routing table.
 func (t *liteTable[V]) All6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRec(stridePath{}, 0, false, yield)
 	}
 }
@@ -585,9 +570,6 @@ func (t *liteTable[V]) All6() iter.Seq2[netip.Prefix, V] {
 // traversal is required use persistent table methods.
 func (t *liteTable[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield) &&
 			t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
@@ -596,9 +578,6 @@ func (t *liteTable[V]) AllSorted() iter.Seq2[netip.Prefix, V] {
 // AllSorted4 is like [liteTable.AllSorted] but only for the v4 routing table.
 func (t *liteTable[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root4.AllRecSorted(stridePath{}, 0, true, yield)
 	}
 }
@@ -606,9 +585,6 @@ func (t *liteTable[V]) AllSorted4() iter.Seq2[netip.Prefix, V] {
 // AllSorted6 is like [liteTable.AllSorted] but only for the v6 routing table.
 func (t *liteTable[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 	return func(yield func(netip.Prefix, V) bool) {
-		if t == nil {
-			return
-		}
 		_ = t.root6.AllRecSorted(stridePath{}, 0, false, yield)
 	}
 }
@@ -636,11 +612,8 @@ func (t *liteTable[V]) AllSorted6() iter.Seq2[netip.Prefix, V] {
 //	   │  └─ 2001:db8::/32 (V)
 //	   └─ fe80::/10 (V)
 func (t *liteTable[V]) Fprint(w io.Writer) error {
-	if w == nil {
+	if w == nil && t != nil {
 		return fmt.Errorf("nil writer")
-	}
-	if t == nil {
-		return nil
 	}
 
 	// v4
@@ -691,10 +664,6 @@ func (t *liteTable[V]) MarshalText() ([]byte, error) {
 // MarshalJSON dumps the table into two sorted lists: for ipv4 and ipv6.
 // Every root and subnet is an array, not a map, because the order matters.
 func (t *liteTable[V]) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-
 	result := struct {
 		Ipv4 []DumpListNode[V] `json:"ipv4,omitempty"`
 		Ipv6 []DumpListNode[V] `json:"ipv6,omitempty"`
@@ -714,18 +683,12 @@ func (t *liteTable[V]) MarshalJSON() ([]byte, error) {
 // DumpList4 dumps the ipv4 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build the text or JSON serialization.
 func (t *liteTable[V]) DumpList4() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root4, 0, stridePath{}, 0, true)
 }
 
 // DumpList6 dumps the ipv6 tree into a list of roots and their subnets.
 // It can be used to analyze the tree or build custom JSON representation.
 func (t *liteTable[V]) DumpList6() []DumpListNode[V] {
-	if t == nil {
-		return nil
-	}
 	return t.dumpListRec(&t.root6, 0, stridePath{}, 0, false)
 }
 
@@ -775,10 +738,6 @@ func (t *liteTable[V]) dumpString() string {
 
 // dump the table structure and all the nodes to w.
 func (t *liteTable[V]) dump(w io.Writer) {
-	if t == nil {
-		return
-	}
-
 	if t.size4 > 0 {
 		stats := t.root4.StatsRec()
 		fmt.Fprintln(w)

--- a/litespecial_test.go
+++ b/litespecial_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestTableNil_LiteTable(t *testing.T) {
+func TestTableNilReceiver_LiteTable(t *testing.T) {
 	t.Parallel()
 
 	ip4 := mpa("127.0.0.1")
@@ -17,21 +17,10 @@ func TestTableNil_LiteTable(t *testing.T) {
 	pfx4 := mpp("127.0.0.0/8")
 	pfx6 := mpp("::1/128")
 
-	tbl2 := new(Lite)
-	tbl2.Insert(pfx4)
-	tbl2.Insert(pfx6)
-
 	var tbl1 *Lite = nil
 
 	t.Run("mustPanic", func(t *testing.T) {
 		t.Parallel()
-
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(true, 1) })
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(false, 1) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(true) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(false) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
 		mustPanic(t, "Size", func() { tbl1.Size() })
 		mustPanic(t, "Size4", func() { tbl1.Size4() })
@@ -48,52 +37,29 @@ func TestTableNil_LiteTable(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
-	})
-
-	t.Run("noPanic", func(t *testing.T) {
-		t.Parallel()
-
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
-
-		noPanic(t, "Overlaps", func() { tbl2.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
-
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		mustPanic(t, "Clone", func() { tbl1.Clone() })
+		mustPanic(t, "Union", func() { tbl1.Union(nil) })
+		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(nil) })
+		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
+		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
+		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		mustPanic(t, "Equal", func() { tbl1.Equal(nil) })
+		mustPanic(t, "DumpList4", func() { tbl1.DumpList4() })
+		mustPanic(t, "DumpList6", func() { tbl1.DumpList6() })
+		mustPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
+		mustPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
+		mustPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
-		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
-
-		mustPanic(t, "dump", func() { tbl1.dump(nil) })
-		mustPanic(t, "dumpString", func() { tbl1.dumpString() })
-		noPanic(t, "Clone", func() { tbl1.Clone() })
-		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
-		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })
-		noPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
-		noPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
-		noPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
-	})
-
-	t.Run("noPanicRangeOverFunc", func(t *testing.T) {
-		t.Parallel()
-
-		noPanicRangeOverFunc[any](t, "All", tbl1.All)
-		noPanicRangeOverFunc[any](t, "All4", tbl1.All4)
-		noPanicRangeOverFunc[any](t, "All6", tbl1.All6)
-		noPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
-		noPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
-		noPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
-		noPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
-		noPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
+		mustPanicRangeOverFunc[any](t, "All", tbl1.All)
+		mustPanicRangeOverFunc[any](t, "All4", tbl1.All4)
+		mustPanicRangeOverFunc[any](t, "All6", tbl1.All6)
+		mustPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
+		mustPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
+		mustPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
+		mustPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
+		mustPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
 	})
 }
 

--- a/litetestsgenerated_test.go
+++ b/litetestsgenerated_test.go
@@ -1,6 +1,6 @@
 // Code generated from file "commontests_tmpl.go"; DO NOT EDIT.
 
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -30,7 +30,7 @@ func (t *liteTable[V]) flatSorted() golden.Table[V] {
 	return flat
 }
 
-func TestTableNil_liteTable(t *testing.T) {
+func TestTableNilReceiver_liteTable(t *testing.T) {
 	t.Parallel()
 
 	ip4 := mpa("127.0.0.1")
@@ -39,21 +39,10 @@ func TestTableNil_liteTable(t *testing.T) {
 	pfx4 := mpp("127.0.0.0/8")
 	pfx6 := mpp("::1/128")
 
-	tbl2 := new(liteTable[any])
-	tbl2.Insert(pfx4, nil)
-	tbl2.Insert(pfx6, nil)
-
 	var tbl1 *liteTable[any] = nil
 
 	t.Run("mustPanic", func(t *testing.T) {
 		t.Parallel()
-
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(true, 1) })
-		mustPanic(t, "sizeUpdate", func() { tbl1.sizeUpdate(false, 1) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(true) })
-		mustPanic(t, "rootNodeByVersion", func() { tbl1.rootNodeByVersion(false) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, true) })
-		mustPanic(t, "fprint", func() { tbl1.fprint(nil, false) })
 
 		mustPanic(t, "Size", func() { tbl1.Size() })
 		mustPanic(t, "Size4", func() { tbl1.Size4() })
@@ -70,52 +59,29 @@ func TestTableNil_liteTable(t *testing.T) {
 		mustPanic(t, "Lookup", func() { tbl1.Lookup(ip6) })
 		mustPanic(t, "LookupPrefix", func() { tbl1.LookupPrefix(pfx4) })
 		mustPanic(t, "LookupPrefixLPM", func() { tbl1.LookupPrefixLPM(pfx4) })
-		mustPanic(t, "Union", func() { tbl1.Union(tbl2) })
-		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(tbl2) })
-	})
-
-	t.Run("noPanic", func(t *testing.T) {
-		t.Parallel()
-
-		noPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
-		noPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
-		noPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
-
-		noPanic(t, "Overlaps", func() { tbl2.Overlaps(tbl2) })
-		noPanic(t, "Overlaps4", func() { tbl2.Overlaps4(tbl2) })
-		noPanic(t, "Overlaps6", func() { tbl2.Overlaps6(tbl2) })
-
-		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(tbl2) })
-		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(tbl2) })
-		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(tbl2) })
+		mustPanic(t, "Clone", func() { tbl1.Clone() })
+		mustPanic(t, "Union", func() { tbl1.Union(nil) })
+		mustPanic(t, "UnionPersist", func() { tbl1.UnionPersist(nil) })
+		mustPanic(t, "Overlaps", func() { tbl1.Overlaps(nil) })
+		mustPanic(t, "Overlaps4", func() { tbl1.Overlaps4(nil) })
+		mustPanic(t, "Overlaps6", func() { tbl1.Overlaps6(nil) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx4) })
 		mustPanic(t, "OverlapsPrefix", func() { tbl1.OverlapsPrefix(pfx6) })
+		mustPanic(t, "Equal", func() { tbl1.Equal(nil) })
+		mustPanic(t, "DumpList4", func() { tbl1.DumpList4() })
+		mustPanic(t, "DumpList6", func() { tbl1.DumpList6() })
+		mustPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
+		mustPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
+		mustPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
 
-		mustPanic(t, "Equal", func() { tbl1.Equal(tbl2) })
-		noPanic(t, "Equal", func() { tbl1.Equal(tbl1) })
-		noPanic(t, "Equal", func() { tbl2.Equal(tbl2) })
-
-		noPanic(t, "dump", func() { tbl1.dump(nil) })
-		noPanic(t, "dumpString", func() { tbl1.dumpString() })
-		noPanic(t, "Clone", func() { tbl1.Clone() })
-		noPanic(t, "DumpList4", func() { tbl1.DumpList4() })
-		noPanic(t, "DumpList6", func() { tbl1.DumpList6() })
-		noPanic(t, "Fprint", func() { tbl1.Fprint(nil) })
-		noPanic(t, "MarshalJSON", func() { _, _ = tbl1.MarshalJSON() })
-		noPanic(t, "MarshalText", func() { _, _ = tbl1.MarshalText() })
-	})
-
-	t.Run("noPanicRangeOverFunc", func(t *testing.T) {
-		t.Parallel()
-
-		noPanicRangeOverFunc[any](t, "All", tbl1.All)
-		noPanicRangeOverFunc[any](t, "All4", tbl1.All4)
-		noPanicRangeOverFunc[any](t, "All6", tbl1.All6)
-		noPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
-		noPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
-		noPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
-		noPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
-		noPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
+		mustPanicRangeOverFunc[any](t, "All", tbl1.All)
+		mustPanicRangeOverFunc[any](t, "All4", tbl1.All4)
+		mustPanicRangeOverFunc[any](t, "All6", tbl1.All6)
+		mustPanicRangeOverFunc[any](t, "AllSorted", tbl1.AllSorted)
+		mustPanicRangeOverFunc[any](t, "AllSorted4", tbl1.AllSorted4)
+		mustPanicRangeOverFunc[any](t, "AllSorted6", tbl1.AllSorted6)
+		mustPanicRangeOverFunc[any](t, "Subnets", tbl1.Subnets)
+		mustPanicRangeOverFunc[any](t, "Supernets", tbl1.Supernets)
 	})
 }
 
@@ -1302,12 +1268,7 @@ func TestTableClone_liteTable(t *testing.T) {
 	prng := rand.New(rand.NewPCG(42, 42))
 	pfxs := random.RealWorldPrefixes(prng, n)
 
-	var tbl *liteTable[int]
-	if tbl.Clone() != nil {
-		t.Fatal("expected nil")
-	}
-
-	tbl = new(liteTable[int])
+	tbl := new(liteTable[int])
 	for i, pfx := range pfxs {
 		tbl.Insert(pfx, i)
 	}

--- a/zz-helpers_test.go
+++ b/zz-helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart
@@ -91,11 +91,11 @@ func noPanic(t *testing.T, name string, fn func()) {
 	fn()
 }
 
-func noPanicRangeOverFunc[V any](t *testing.T, name string, fn any) {
+func mustPanicRangeOverFunc[V any](t *testing.T, name string, fn any) {
 	t.Helper()
 	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("%s panicked: %v", name, r)
+		if recover() == nil {
+			t.Fatalf("%s must panic", name)
 		}
 	}()
 


### PR DESCRIPTION
Behavior Changes:
Many table methods and serializers now assume non-nil receivers and will panic if called on nil, removing prior silent no-ops.

Tests:
Tests updated to assert panics for nil-receiver behavior across cloning, unions, equality/overlap checks, serialization/print/dump, and range-iteration helpers; auxiliary-table setups simplified.