### PR TITLE
avoid possible allocation in Table.Contains()

### DIFF
--- a/bart.go
+++ b/bart.go
@@ -133,7 +133,16 @@ func (t *Table[V]) Contains(ip netip.Addr) bool {
 	is4 := ip.Is4()
 	n := t.rootNodeByVersion(is4)
 
-	for _, octet := range ip.AsSlice() {
+	var octets []byte
+	if ip.Is4() {
+		x := ip.As4()
+		octets = x[:]
+	} else if ip.Is6() {
+		x := ip.As16()
+		octets = x[:]
+	}
+
+	for _, octet := range octets {
 		// for contains, any lpm match is good enough, no backtracking needed
 		if n.PrefixCount() != 0 && n.Contains(art.OctetToIdx(octet)) {
 			return true

--- a/fast.go
+++ b/fast.go
@@ -143,7 +143,16 @@ func (f *Fast[V]) Contains(ip netip.Addr) bool {
 	is4 := ip.Is4()
 	n := f.rootNodeByVersion(is4)
 
-	for _, octet := range ip.AsSlice() {
+	var octets []byte
+	if ip.Is4() {
+		x := ip.As4()
+		octets = x[:]
+	} else if ip.Is6() {
+		x := ip.As16()
+		octets = x[:]
+	}
+
+	for _, octet := range octets {
 		if n.Contains(art.OctetToIdx(octet)) {
 			return true
 		}

--- a/lite.go
+++ b/lite.go
@@ -576,7 +576,16 @@ func (l *liteTable[V]) Contains(ip netip.Addr) bool {
 	is4 := ip.Is4()
 	n := l.rootNodeByVersion(is4)
 
-	for _, octet := range ip.AsSlice() {
+	var octets []byte
+	if ip.Is4() {
+		x := ip.As4()
+		octets = x[:]
+	} else if ip.Is6() {
+		x := ip.As16()
+		octets = x[:]
+	}
+
+	for _, octet := range octets {
 		// for contains, any lpm match is good enough, no backtracking needed
 		if n.Prefixes.Count != 0 && n.Contains(art.OctetToIdx(octet)) {
 			return true


### PR DESCRIPTION
Today I saw `bart.(*liteTable[go.shape.struct {}]).Contains` show up in a heap profile, right above `netip.Addr.AsSlice` in the flamegraph. When I attempt to isolate this behavior in a benchmark with benchmem, it doesn't show up (my tests and bart's own tests all report 0 allocs/op). 

I've attached a copy of the profile "blaming" bart here: [bartcontains.pprof.gz](https://github.com/user-attachments/files/26947217/bartcontains.pprof.gz)

When I make this change in this PR, the allocation disappears from my heap profile. Honestly I feel like a crazy person. This shouldn't matter, `netip.Addr.AsSlice` is even getting inlined! 

I'm happy to tweak this, or apply it to functions other than just .Contains() if you want.

All my tests were done with `go version go1.26.2-X:nodwarf5 linux/amd64`, in case that ends up mattering.

