### PR TITLE
Refactor concurrent tests with explicit goroutine orchestration

### DIFF
--- a/example_fast_concurrent_test.go
+++ b/example_fast_concurrent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart_test
@@ -32,21 +32,44 @@ func ExampleFast_concurrent() {
 	baseTbl := new(bart.Fast[*testVal])
 	tblAtomicPtr.Store(baseTbl)
 
-	wg := sync.WaitGroup{}
+	var readerWg sync.WaitGroup
+	var writerWg sync.WaitGroup
 
-	wg.Add(1)
+	// Unbuffered channel acts as a synchronized starting gun.
+	// All goroutines will block on this channel until it is closed.
+	startSignal := make(chan struct{})
+
+	// Channel to signal when all writers have finished.
+	writersDone := make(chan struct{})
+
+	// 1. GOROUTINE: READERS
+	// Tracked by the reader wg. Runs until writersDone is closed.
+	readerWg.Add(1)
 	go func() {
-		defer wg.Done()
-		for range 100_000 {
-			for _, ip := range exampleIPs {
-				_, _ = tblAtomicPtr.Load().Lookup(ip)
+		defer readerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
+		var localSink bool
+		for {
+			select {
+			case <-writersDone: // stop when all writers finished
+				_ = localSink
+				return
+			default:
+				for _, ip := range exampleIPs {
+					localSink = tblAtomicPtr.Load().Contains(ip)
+				}
 			}
 		}
 	}()
 
-	wg.Add(1)
+	// 2. GOROUTINE: WRITER (INSERTS)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
 		for range 1_000 {
 			tblMutex.Lock()
 			cur := tblAtomicPtr.Load()
@@ -62,9 +85,13 @@ func ExampleFast_concurrent() {
 		}
 	}()
 
-	wg.Add(1)
+	// 3. GOROUTINE: WRITER (DELETES)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
 		for range 1_000 {
 			tblMutex.Lock()
 			cur := tblAtomicPtr.Load()
@@ -80,7 +107,20 @@ func ExampleFast_concurrent() {
 		}
 	}()
 
-	wg.Wait()
+	// Orchestration: Monitor the writers, signal the reader, and orchestrate shutdown.
+	go func() {
+		<-startSignal // Block until the starting gun fires
+		writerWg.Wait()
+		close(writersDone)
+	}()
+
+	// At this point, all goroutines are initialized and waiting.
+	// Closing the channel releases all of them at the exact same fraction of a second.
+	close(startSignal)
+
+	// We only need to wait for the reader (wg), because the reader will
+	// only exit after writersDone is closed, which only happens after all writers are done.
+	readerWg.Wait()
 
 	// Output:
 }

--- a/example_lite_concurrent_test.go
+++ b/example_lite_concurrent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart_test
@@ -28,21 +28,45 @@ func ExampleLite_concurrent() {
 	baseTbl := new(bart.Lite)
 	liteAtomicPtr.Store(baseTbl)
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	var readerWg sync.WaitGroup
+	var writerWg sync.WaitGroup
+
+	// Unbuffered channel acts as a synchronized starting gun.
+	// All goroutines will block on this channel until it is closed.
+	startSignal := make(chan struct{})
+
+	// Channel to signal when all writers have finished.
+	writersDone := make(chan struct{})
+
+	// 1. GOROUTINE: READERS
+	// Tracked by the reader wg. Runs until writersDone is closed.
+	readerWg.Add(1)
 	go func() {
-		defer wg.Done()
-		for range 10_000 {
-			for _, ip := range exampleIPs {
-				_ = liteAtomicPtr.Load().Contains(ip)
+		defer readerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
+		var localSink bool
+		for {
+			select {
+			case <-writersDone: // stop when all writers finished
+				_ = localSink
+				return
+			default:
+				for _, ip := range exampleIPs {
+					localSink = liteAtomicPtr.Load().Contains(ip)
+				}
 			}
 		}
 	}()
 
-	wg.Add(1)
+	// 2. GOROUTINE: WRITER (INSERTS)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
-		for range 1000 {
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
+		for range 1_000 {
 			liteMutex.Lock()
 			cur := liteAtomicPtr.Load()
 
@@ -57,10 +81,14 @@ func ExampleLite_concurrent() {
 		}
 	}()
 
-	wg.Add(1)
+	// 3. GOROUTINE: WRITER (DELETES)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
-		for range 1000 {
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
+		for range 1_000 {
 			liteMutex.Lock()
 			cur := liteAtomicPtr.Load()
 
@@ -75,7 +103,20 @@ func ExampleLite_concurrent() {
 		}
 	}()
 
-	wg.Wait()
+	// Orchestration: Monitor the writers, signal the reader, and orchestrate shutdown.
+	go func() {
+		<-startSignal // Block until the starting gun fires
+		writerWg.Wait()
+		close(writersDone)
+	}()
+
+	// At this point, all goroutines are initialized and waiting.
+	// Closing the channel releases all of them at the exact same fraction of a second.
+	close(startSignal)
+
+	// We only need to wait for the reader (wg), because the reader will
+	// only exit after writersDone is closed, which only happens after all writers are done.
+	readerWg.Wait()
 
 	// Output:
 }

--- a/example_table_concurrent_test.go
+++ b/example_table_concurrent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Karl Gaissmaier
+// Copyright (c) 2026 Karl Gaissmaier
 // SPDX-License-Identifier: MIT
 
 package bart_test
@@ -9,20 +9,6 @@ import (
 
 	"github.com/gaissmai/bart"
 )
-
-// We use *testVal as the generic payload type V (a pointer type).
-type testVal struct {
-	data int
-}
-
-// Clone enables deep copying for ...Persist operations.
-// Detected via structural typing (presence of a matching Clone method).
-func (v *testVal) Clone() *testVal {
-	if v == nil {
-		return nil
-	}
-	return &testVal{data: v.data}
-}
 
 // #######################################
 
@@ -46,21 +32,44 @@ func ExampleTable_concurrent() {
 	baseTbl := new(bart.Table[*testVal])
 	tblAtomicPtr.Store(baseTbl)
 
-	wg := sync.WaitGroup{}
+	var readerWg sync.WaitGroup
+	var writerWg sync.WaitGroup
 
-	wg.Add(1)
+	// Unbuffered channel acts as a synchronized starting gun.
+	// All goroutines will block on this channel until it is closed.
+	startSignal := make(chan struct{})
+
+	// Channel to signal when all writers have finished.
+	writersDone := make(chan struct{})
+
+	// 1. GOROUTINE: READERS
+	// Tracked by the reader wg. Runs until writersDone is closed.
+	readerWg.Add(1)
 	go func() {
-		defer wg.Done()
-		for range 100_000 {
-			for _, ip := range exampleIPs {
-				_, _ = tblAtomicPtr.Load().Lookup(ip)
+		defer readerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
+		var localSink bool
+		for {
+			select {
+			case <-writersDone: // stop when all writers finished
+				_ = localSink
+				return
+			default:
+				for _, ip := range exampleIPs {
+					localSink = tblAtomicPtr.Load().Contains(ip)
+				}
 			}
 		}
 	}()
 
-	wg.Add(1)
+	// 2. GOROUTINE: WRITER (INSERTS)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
 		for range 1_000 {
 			tblMutex.Lock()
 			cur := tblAtomicPtr.Load()
@@ -76,9 +85,13 @@ func ExampleTable_concurrent() {
 		}
 	}()
 
-	wg.Add(1)
+	// 3. GOROUTINE: WRITER (DELETES)
+	// Tracked only by writer wg
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
+		<-startSignal // Block until the starting gun fires
+
 		for range 1_000 {
 			tblMutex.Lock()
 			cur := tblAtomicPtr.Load()
@@ -94,7 +107,20 @@ func ExampleTable_concurrent() {
 		}
 	}()
 
-	wg.Wait()
+	// Orchestration: Monitor the writers, signal the reader, and orchestrate shutdown.
+	go func() {
+		<-startSignal // Block until the starting gun fires
+		writerWg.Wait()
+		close(writersDone)
+	}()
+
+	// At this point, all goroutines are initialized and waiting.
+	// Closing the channel releases all of them at the exact same fraction of a second.
+	close(startSignal)
+
+	// We only need to wait for the reader (wg), because the reader will
+	// only exit after writersDone is closed, which only happens after all writers are done.
+	readerWg.Wait()
 
 	// Output:
 }

--- a/example_test.go
+++ b/example_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/gaissmai/bart"
 )
 
+// We use *testVal as the generic payload type V (a pointer type).
+type testVal struct {
+	data int
+}
+
+// Clone enables deep copying for ...Persist operations.
+// Detected via structural typing (presence of a matching Clone method).
+func (v *testVal) Clone() *testVal {
+	if v == nil {
+		return nil
+	}
+	return &testVal{data: v.data}
+}
+
 var (
 	mpa = netip.MustParseAddr
 	mpp = netip.MustParsePrefix


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrent test examples: readers now run concurrently with two separate writer streams (inserts and deletes) to more aggressively exercise concurrent access.
  * Added coordination so all goroutines start together and the reader stops when writers finish, improving reliability and race detection.
  * Introduced a new internal test payload type with cloning support for safer value handling in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->