### PR TITLE
refactor: clarify stride calculation and fringe terminology

### DIFF
--- a/bart.go
+++ b/bart.go
@@ -281,10 +281,10 @@ func (t *Table[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx netip
 	pfx = pfx.Masked()
 
 	ip := pfx.Addr()
-	bits := pfx.Bits()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := nodes.DivMod8(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfxLen)
 
 	n := t.rootNodeByVersion(is4)
 
@@ -321,7 +321,7 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > bits || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
 				break LOOP
 			}
 			return kid.Prefix, kid.Value, true
@@ -330,7 +330,7 @@ LOOP:
 			// the bits of the fringe are defined by the depth
 			// maybe the LPM isn't needed, saves some cycles
 			fringeBits := (depth + 1) << 3
-			if fringeBits > bits {
+			if fringeBits > pfxLen {
 				break LOOP
 			}
 

--- a/bart.go
+++ b/bart.go
@@ -284,7 +284,7 @@ func (t *Table[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx netip
 	bits := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := nodes.LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfx)
 
 	n := t.rootNodeByVersion(is4)
 
@@ -300,7 +300,7 @@ LOOP:
 		depth &= nodes.DepthMask // BCE
 
 		// stepped one past the last stride of interest; back up to last and break
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -362,9 +362,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4 or 16),
+		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)

--- a/bart.go
+++ b/bart.go
@@ -361,9 +361,9 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
-		// so those are handled below via the fringe/leaf path.
+		// so those are handled above via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {

--- a/fast.go
+++ b/fast.go
@@ -285,10 +285,10 @@ func (f *Fast[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx netip.
 	pfx = pfx.Masked()
 
 	ip := pfx.Addr()
-	bits := pfx.Bits()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := nodes.DivMod8(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfxLen)
 
 	n := f.rootNodeByVersion(is4)
 
@@ -325,7 +325,7 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > bits || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
 				break LOOP
 			}
 			return kid.Prefix, kid.Value, true
@@ -334,7 +334,7 @@ LOOP:
 			// the bits of the fringe are defined by the depth
 			// maybe the LPM isn't needed, saves some cycles
 			fringeBits := (depth + 1) << 3
-			if fringeBits > bits {
+			if fringeBits > pfxLen {
 				break LOOP
 			}
 

--- a/fast.go
+++ b/fast.go
@@ -365,9 +365,9 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
-		// so those are handled below via the fringe/leaf path.
+		// so those are handled above via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {

--- a/fast.go
+++ b/fast.go
@@ -288,7 +288,7 @@ func (f *Fast[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx netip.
 	bits := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := nodes.LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfx)
 
 	n := f.rootNodeByVersion(is4)
 
@@ -304,7 +304,7 @@ LOOP:
 		depth &= nodes.DepthMask // BCE
 
 		// stepped one past the last stride of interest; back up to last and break
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -366,9 +366,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4 or 16),
+		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)

--- a/internal/nodes/bart.go
+++ b/internal/nodes/bart.go
@@ -11,29 +11,31 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// BartNode is a trie level node in the multibit routing table.
+// BartNode represents a single trie level in the multibit routing table.
 //
-// Each BartNode contains two conceptually different arrays:
+// Unlike the original ART algorithm, this implementation uses popcount-compressed
+// sparse arrays instead of fixed-size allocations. Insertions and lookups rely on
+// fast bitset operations and precomputed rank indexes to maximize CPU cache efficiency.
 //
-//   - Prefixes stores routing entries (prefix -> value),
-//     laid out as a complete binary tree using the baseIndex()
-//     function from the ART algorithm.
+// Each BartNode maintains two distinct sparse arrays:
 //
-//   - Children: holding subtries or path-compressed leaves/fringes with
-//     a branching factor of 256 (8 bits per stride).
+//  1. Prefixes: Stores routing entries (prefix -> value) for the current stride.
+//     These are laid out as a complete binary tree using the baseIndex()
+//     function mapping from the ART algorithm. Prefixes that match exactly at
+//     the maximum trie depth are always stored here.
 //
-// Entries in Children may be:
-//   - *BartNode[V]   -> internal child node for further traversal
-//   - *LeafNode[V]   -> path-comp. node (depth < maxDepth - 1)
-//   - *FringeNode[V] -> path-comp. node (depth == maxDepth - 1, stride-aligned: /8, /16, ... /128)
+//  2. Children: Holds pointers to the next logical levels with a branching
+//     factor of 256 (8 bits per stride).
 //
-// Note: Both *LeafNode and *FringeNode entries are only created by path compression.
-// Prefixes that match exactly at the maximum trie depth (depth == maxDepth) are
-// never stored as Children, but always directly in the prefixes array at that level.
+// A slot in the Children array may contain one of three types:
+//   - *BartNode[V]:   An internal intermediate node for further trie traversal.
+//   - *LeafNode[V]:   A path-compressed node for unaligned prefixes (depth < strideCount - 1).
+//   - *FringeNode[V]: A path-compressed node for stride-aligned prefixes (/8, /16, ... /128).
+//     Occurs only at (depth == strideCount - 1).
 //
-// Unlike the original ART, this implementation uses popcount-compressed sparse arrays
-// instead of fixed-size arrays. Array slots are not pre-allocated; insertion
-// and lookup rely on fast bitset operations and precomputed rank indexes.
+// Note: LeafNode and FringeNode are created through path compression and
+// are automatically split into regular BartNodes when a more specific prefix
+// is inserted that requires further branching.
 type BartNode[V any] struct {
 	Prefixes sparse.Array256[V]
 	Children sparse.Array256[any]

--- a/internal/nodes/bart_test.go
+++ b/internal/nodes/bart_test.go
@@ -1722,7 +1722,7 @@ func TestBartNode_Modify_AllPaths(t *testing.T) {
 		t.Parallel()
 		n := &BartNode[int]{}
 
-		// Use /0 for depth=0, lastOctetPlusOne=0, so depth == lastOctetPlusOne
+		// Use /0 for depth=0, strideCount=0, so depth == strideCount
 		delta := n.Modify(mpp("0.0.0.0/0"), func(val int, found bool) (int, bool) {
 			if found {
 				t.Error("Should not find non-existent prefix")

--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -37,8 +37,9 @@ import (
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -58,7 +59,7 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -95,7 +96,7 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -141,8 +142,9 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -162,7 +164,7 @@ func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -202,7 +204,7 @@ func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -320,9 +322,10 @@ func (n *BartNode[V]) PurgeAndCompress(stack []*BartNode[V], octets []uint8, is4
 // now-empty nodes and restore path compression upward.
 func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -360,7 +363,7 @@ func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -403,9 +406,10 @@ func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 // now-empty nodes and restore path compression upward.
 func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -450,7 +454,7 @@ func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -499,8 +503,9 @@ func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 func (n *BartNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
@@ -525,7 +530,7 @@ func (n *BartNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 		case *FringeNode[V]:
 			// Reached a path-compressed FringeNode.
 			// Verify if the prefix qualifies as a fringe at this depth to return a match.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return kid.Value, true
 			}
 			return val, false
@@ -564,9 +569,10 @@ func (n *BartNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	var zero V
 
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -623,7 +629,7 @@ func (n *BartNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 			}
 
 			// insert
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				n.InsertChild(octet, NewFringeNode(newVal))
 			} else {
 				n.InsertChild(octet, NewLeafNode(pfx, newVal))
@@ -682,7 +688,7 @@ func (n *BartNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 
 		case *FringeNode[V]:
 			// update existing value if prefix is fringe
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				newVal, del := cb(kid.Value, true)
 				if !del {
 					kid.Value = newVal
@@ -1913,9 +1919,10 @@ func (n *BartNode[V]) EachSubnet(octets []byte, depth int, is4 bool, pfxIdx uint
 // the iteration early.
 func (n *BartNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*BartNode[V]{}
@@ -2029,9 +2036,10 @@ LOOP:
 func (n *BartNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// find the trie node
 	for depth, octet := range octets {
@@ -2300,8 +2308,9 @@ func (n *BartNode[V]) OverlapsSameChildren(o *BartNode[V], depth int) bool {
 // trie traversal across varying prefix lengths and compression levels.
 func (n *BartNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	for ; depth < len(octets); depth++ {
 		if depth > strideCount {

--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -17,65 +17,75 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// Insert inserts a network prefix and its associated value into the
-// trie starting at the specified byte depth.
+// Insert adds or updates a network prefix and its associated value in the trie.
+// Traversal begins at the specified byte depth.
 //
-// The function traverses the prefix address from the given depth and inserts
-// the value either directly into the node's prefix table or as a compressed
-// leaf or fringe node. If a conflicting leaf or fringe exists, it creates
-// a new intermediate node to accommodate both entries.
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// Insert resolves the collision by creating a new intermediate node, pushing
+// the existing entry down to the next level, and continuing traversal.
 //
 // Parameters:
-//   - pfx: The network prefix to insert (must be in canonical form)
-//   - val: The value to associate with the prefix
-//   - depth: The current depth in the trie (0-based byte index)
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
 //
-// Returns true if a prefix already existed and was updated, false for new insertions.
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *BartNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next trie level.
+			n = kid
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(BartNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -83,18 +93,17 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(BartNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -108,63 +117,82 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	panic("unreachable")
 }
 
-// InsertPersist is similar to insert but the receiver isn't modified.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// InsertPersist adds or updates a network prefix and its associated value in the trie
+// using Copy-On-Write (COW) semantics. Traversal begins at the specified byte depth.
+//
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// Unlike Insert, InsertPersist ensures structural integrity of the existing tree
+// by cloning internal nodes along the descent path (Copy-On-Write) before mutation.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// InsertPersist resolves the collision by creating a new intermediate node,
+// pushing the existing entry down to the next level, and continuing traversal.
+//
+// Parameters:
+//   - cloneFn: The function used to clone values (V).
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
+//
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *BartNode[V]:
-			// clone the traversed path
-
-			// kid points now to cloned kid
+			// Standard intermediate node: Clone the traversed path to maintain persistence (COW).
+			// We clone the child node before modifying it, then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// replace kid with clone
 			n.InsertChild(octet, kid)
-
 			n = kid
-			continue // descend down to next trie level
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(BartNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -172,18 +200,17 @@ func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(BartNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -193,30 +220,31 @@ func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		default:
 			panic("logic error, wrong node type")
 		}
-
 	}
-
 	panic("unreachable")
 }
 
-// PurgeAndCompress performs bottom-up compression of the trie.
+// PurgeAndCompress performs bottom-up trie maintenance to restore path compression
+// after a deletion. It unwinds the provided stack of parent nodes, identifying
+// nodes that have become sparse (i.e., containing only a single prefix or a single
+// child node) and prunes them by promoting the underlying entries to the parent level.
 //
-// The function unwinds the provided stack of parent nodes, checking each level
-// for compression opportunities based on child and prefix count.
-// It may convert:
-//   - Nodes with a single prefix into leaf one level above.
-//   - Nodes with a single leaf or fringe into leaf one level above.
+// This ensures the trie remains memory-efficient by collapsing redundant intermediate
+// nodes back into path-compressed LeafNodes or FringeNodes whenever possible.
 //
 // Parameters:
-//   - stack: Array of parent nodes to process during unwinding
-//   - octets: The path of octets taken to reach the current position
-//   - is4: True for IPv4 processing, false for IPv6
+//   - stack: Array of parent nodes to process during bottom-up unwinding.
+//   - octets: The full path of octets leading to the current node.
+//   - is4: True for IPv4 processing, false for IPv6.
 func (n *BartNode[V]) PurgeAndCompress(stack []*BartNode[V], octets []uint8, is4 bool) {
-	// unwind the stack
+	// Iterate backwards through the ancestor stack to prune nodes from the bottom up.
 	for depth := len(stack) - 1; depth >= 0; depth-- {
 		parent := stack[depth]
 		octet := octets[depth]
 
+		// Check if the current node is redundant.
+		// A node is redundant if it contains exactly one entry (either a prefix or a child node).
+		// If it contains more than one entry, it is structurally significant and cannot be pruned.
 		pfxCount := n.PrefixCount()
 		childCount := n.ChildCount()
 
@@ -226,129 +254,133 @@ func (n *BartNode[V]) PurgeAndCompress(stack []*BartNode[V], octets []uint8, is4
 
 		switch {
 		case childCount == 1:
-			singleAddr, _ := n.Children.FirstSet() // single addr must be first bit set
+			// The node has exactly one child. We determine if it is a path node,
+			// a compressed LeafNode, or a compressed FringeNode.
+			singleAddr, _ := n.Children.FirstSet()
 			anyKid := n.MustGetChild(singleAddr)
 
 			switch kid := anyKid.(type) {
 			case *BartNode[V]:
-				// fast exit, we are at an intermediate path node
-				// no further delete/compress upwards the stack is possible
+				// The child is an intermediate path node; the tree structure is required
+				// at this level. Compression cannot proceed further up.
 				return
 			case *LeafNode[V]:
-				// just one leaf, delete this node and reinsert the leaf above
+				// The child is a compressed LeafNode. Prune the current empty node
+				// and re-insert the leaf into the parent to elevate it.
 				parent.DeleteChild(octet)
-
-				// ... (re)insert the leaf at parents depth
 				parent.Insert(kid.Prefix, kid.Value, depth)
 			case *FringeNode[V]:
-				// just one fringe, delete this node and reinsert the fringe as leaf above
+				// The child is a compressed FringeNode. Prune the current node
+				// and re-insert the fringe as a leaf into the parent.
 				parent.DeleteChild(octet)
 
-				// rebuild the prefix with octets, depth, ip version and addr
-				// depth is the parent's depth, so add +1 here for the kid
-				// lastOctet in cidrForFringe is the only addr (singleAddr)
+				// Reconstruct the full prefix for the fringe, as path compression
+				// requires the entire CIDR path, not just the remainder.
+				// depth is the parent's depth, so we offset by 1 for the kid's position.
 				fringePfx := CidrForFringe(octets, depth+1, is4, singleAddr)
 
-				// ... (re)reinsert prefix/value at parents depth
 				parent.Insert(fringePfx, kid.Value, depth)
 			}
 
 		case pfxCount == 1:
-			// just one prefix, delete this node and reinsert the idx as leaf above
+			// The node has exactly one prefix. Prune the node and elevate the
+			// prefix to the parent level as a leaf/fringe.
 			parent.DeleteChild(octet)
 
-			// get prefix back from idx ...
-			idx, _ := n.Prefixes.FirstSet() // single idx must be first bit set
+			// Retrieve the single prefix stored in this node.
+			idx, _ := n.Prefixes.FirstSet()
 			val := n.MustGetPrefix(idx)
 
-			// ... and octet path
+			// Reconstruct the prefix from the path for re-insertion.
 			path := StridePath{}
 			copy(path[:], octets)
-
-			// depth is the parent's depth, so add +1 here for the kid
 			pfx := CidrFromPath(path, depth+1, is4, idx)
 
-			// ... (re)insert prefix/value at parents depth
 			parent.Insert(pfx, val, depth)
 		}
 
-		// climb up the stack
+		// Move up to the next parent in the stack to continue pruning.
 		n = parent
 	}
 }
 
-// Delete deletes the prefix and returns true if the prefix existed,
-// or false otherwise. The prefix must be in canonical form.
+// Delete removes the prefix from the trie rooted at n and returns true if the
+// prefix existed, false if it was not found. The prefix must be in canonical
+// (masked) form.
+//
+// The trie uses path compression, so a prefix may be stored in one of three ways:
+//   - In the current node's prefix table when the prefix length aligns exactly
+//     with the stride boundary at this depth (depth == strideCount).
+//   - As a path-compressed FringeNode in a child slot for stride-aligned prefixes
+//     (e.g. /8, /16, /24); occurs at depth == strideCount-1.
+//   - As a path-compressed LeafNode in a child slot for prefixes that fall
+//     between stride boundaries.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
-	ip := pfx.Addr()
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// record the nodes on the path to the deleted node, needed to purge
-	// and/or path compress nodes after the deletion of a prefix
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
 	stack := [MaxTreeDepth]*BartNode[V]{}
 
-	// find the trie node
 	for depth, octet := range octets {
-		depth &= DepthMask // BCE, Delete must be fast
+		depth &= DepthMask // BCE hint; keep Delete on the fast path
 
-		// push current node on stack for path recording
-		stack[depth] = n
+		stack[depth] = n // record current node before descending
 
-		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
 			}
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
 			return true
 		}
 
+		// no child node exists at this octet; the prefix is not in the trie
 		if !n.Children.Test(octet) {
 			return false
 		}
+
+		// A child node exists at this octet path, retrieve it.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf or fringe at octet
 		switch kid := kid.(type) {
 		case *BartNode[V]:
-			n = kid // descend down to next trie level
+			n = kid // descend to the next trie level
 
 		case *FringeNode[V]:
-			// if pfx is no fringe at this depth, fast exit
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
 				return false
 			}
 
-			// pfx is fringe at depth, delete fringe
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Attention: pfx must be masked to be comparable!
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
 				return false
 			}
 
-			// prefix is equal leaf, delete leaf
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
@@ -359,142 +391,148 @@ func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	panic("unreachable")
 }
 
-// DeletePersist is similar to delete but does not mutate the original trie.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// DeletePersist removes the prefix from the trie rooted at n using Copy-On-Write (COW) semantics.
+// It returns true if the prefix existed, false if it was not found. The prefix must be in
+// canonical (masked) form.
+//
+// Like Delete, this method uses path compression. However, DeletePersist ensures
+// the structural integrity of the existing tree by cloning internal nodes along the
+// descent path (COW) before mutation.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
-	ip := pfx.Addr() // the pfx must be in canonical form
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// Stack to keep track of cloned nodes along the path,
-	// needed for purge and path compression after delete.
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
+	// Since this is a COW operation, we store the cloned nodes here.
 	stack := [MaxTreeDepth]*BartNode[V]{}
 
-	// Traverse the trie to locate the prefix to delete.
 	for depth, octet := range octets {
-		// Keep track of the cloned node at current depth.
-		stack[depth] = n
+		depth &= DepthMask // BCE hint; keep DeletePersist on the fast path
+		stack[depth] = n   // record current node before descending
 
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
-				// Prefix not found, nothing deleted.
 				return false
 			}
 
-			// After deletion, purge nodes and compress the path if needed.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 		}
 
-		addr := octet
-
-		// If child node doesn't exist, no prefix to delete.
-		if !n.Children.Test(addr) {
+		// no child node exists at this octet; the prefix is not in the trie
+		if !n.Children.Test(octet) {
 			return false
 		}
 
-		// Fetch child node at current address.
-		kid := n.MustGetChild(addr)
+		// A child node exists at this octet path, retrieve it to either continue
+		// our descent or perform a persistent delete on a compressed node.
+		kid := n.MustGetChild(octet)
 
 		switch kid := kid.(type) {
 		case *BartNode[V]:
-			// Clone the internal node for copy-on-write.
+			// Standard intermediate node: Clone the traversed path to maintain
+			// persistence (COW). We clone the child node before modifying it,
+			// then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// Replace child with cloned node.
-			n.InsertChild(addr, kid)
-
-			// Descend to cloned child node.
+			n.InsertChild(octet, kid)
 			n = kid
 			continue
 
 		case *FringeNode[V]:
-			// Reached a path compressed fringe.
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
-				// Prefix to delete not found here.
 				return false
 			}
 
-			// Delete the fringe node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Reached a path compressed leaf node.
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
-				// Leaf prefix does not match; nothing to delete.
 				return false
 			}
 
-			// Delete leaf node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
-			// Unexpected node type indicates a logic error.
 			panic("logic error, wrong node type")
 		}
 	}
 
-	// Should never happen: traversal always returns or panics inside loop.
 	panic("unreachable")
 }
 
 // Get retrieves the value associated with the given network prefix.
-// Returns the stored value and true if the prefix exists in this node,
-// zero value and false if the prefix is not found.
+// Traversal descends through the trie using the prefix's octets.
+//
+// The lookup handles path compression transparently:
+//   - If the path matches an internal node at the target stride, the value is retrieved
+//     from the node's prefix table.
+//   - If the path leads to a compressed LeafNode or FringeNode, the function verifies
+//     the prefix match before returning the value.
 //
 // Parameters:
-//   - pfx: The network prefix to look up (must be in canonical form)
+//   - pfx: The network prefix to look up (must be in canonical form).
 //
 // Returns:
-//   - val: The value associated with the prefix (zero value if not found)
-//   - exists: True if the prefix was found, false otherwise
+//   - val: The value associated with the prefix (zero value if not found).
+//   - exists: True if the prefix was found, false otherwise.
 func (n *BartNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
+	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the trie node
+	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
+		// At the target stride boundary, the prefix is expected in this node's
+		// prefix table.
 		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
+		// If no child exists at this path, the prefix is not in the trie.
 		kidAny, ok := n.GetChild(octet)
 		if !ok {
 			return val, false
 		}
 
-		// kid is node or leaf or fringe at octet
+		// Identify the node type at this path segment.
 		switch kid := kidAny.(type) {
 		case *BartNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next level.
+			n = kid
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe, stop traversing
+			// Reached a path-compressed FringeNode.
+			// Verify if the prefix qualifies as a fringe at this depth to return a match.
 			if IsFringe(depth, pfx) {
 				return kid.Value, true
 			}
 			return val, false
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix, stop traversing
+			// Reached a path-compressed LeafNode.
+			// Check if the stored prefix matches the lookup prefix exactly.
 			if kid.Prefix == pfx {
 				return kid.Value, true
 			}
@@ -512,7 +550,7 @@ func (n *BartNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 // The callback receives the current value (if found) and existence flag, and returns
 // a new value and deletion flag.
 //
-// modify returns the size delta (-1, 0, +1).
+// Modify returns the size delta (-1, 0, +1).
 // This method handles path traversal, node creation for new paths, and automatic
 // purge/compress operations after deletions.
 //
@@ -774,8 +812,8 @@ func (n *BartNode[V]) EqualRec(o *BartNode[V]) bool {
 //
 // It returns immediately if n is nil or empty. For each visited internal node
 // it calls dump to write the node's representation, then iterates its child
-// addresses and recurses into children that implement nodeDumper[V] (internal
-// subnodes). The path slice and depth together represent the byte-wise path
+// addresses and recurses into children of type *BartNode[V] (internal subnodes).
+// The path slice and depth together represent the byte-wise path
 // from the root to the current node; depth is incremented for each recursion.
 // The is4 flag controls IPv4/IPv6 formatting used by dump.
 func (n *BartNode[V]) DumpRec(w io.Writer, path StridePath, depth int, is4 bool) {
@@ -967,7 +1005,7 @@ func (n *BartNode[V]) DumpString(octets []uint8, depth int, is4 bool) string {
 //   - stopNode: has children but no subnodes (nodes == 0)
 //   - halfNode: contains at least one leaf or fringe and also has subnodes, but
 //     no prefixes
-//   - fullNode: has prefixes or leaves/fringes and also has subnodes
+//   - fullNode: has prefixes and also has subnodes
 //   - pathNode: has subnodes only (no prefixes, leaves, or fringes)
 //
 // The order of these checks is significant to ensure the correct classification.
@@ -1024,7 +1062,7 @@ func (n *BartNode[V]) Stats() (s StatsT) {
 // It walks the node tree recursively and sums immediate counts (prefixes and
 // child slots) plus the number of nodes, leaves, and fringe nodes in the
 // subtree. If n is nil or empty, a zeroed stats is returned. The returned
-// stats.nodes includes the current node. The function will panic if a child
+// SubNodes count includes the current node. The function will panic if a child
 // has an unexpected concrete type.
 func (n *BartNode[V]) StatsRec() (s StatsT) {
 	if n == nil || n.IsEmpty() {
@@ -1178,7 +1216,7 @@ func (n *BartNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				path[depth] = addr
 				directItems = append(directItems, kid.DirectItemsRec(0, path, depth+1, is4)...)
 
-			case *LeafNode[V]: // path-compressed child, stop's recursion for this child
+			case *LeafNode[V]: // path-compressed child, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1187,7 +1225,7 @@ func (n *BartNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				}
 				directItems = append(directItems, item)
 
-			case *FringeNode[V]: // path-compressed fringe, stop's recursion for this child
+			case *FringeNode[V]: // path-compressed fringe, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1951,9 +1989,8 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
@@ -1998,7 +2035,7 @@ func (n *BartNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 
 	// find the trie node
 	for depth, octet := range octets {
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
@@ -2120,7 +2157,7 @@ func (n *BartNode[V]) Overlaps(o *BartNode[V], depth int) bool {
 // OverlapsRoutes compares the prefix sets of two nodes (n and o).
 //
 // It first checks for direct bitset intersection (identical indices),
-// then walks both prefix sets using lpmTest to detect if any
+// then walks both prefix sets using the Contains method to detect if any
 // of the n-prefixes is contained in o, or vice versa.
 func (n *BartNode[V]) OverlapsRoutes(o *BartNode[V]) bool {
 	// some prefixes are identical, trivial overlap

--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -34,7 +34,7 @@ import (
 func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -42,7 +42,7 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -114,7 +114,7 @@ func (n *BartNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -122,7 +122,7 @@ func (n *BartNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -286,7 +286,7 @@ func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -300,9 +300,9 @@ func (n *BartNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
@@ -366,7 +366,7 @@ func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 	ip := pfx.Addr() // the pfx must be in canonical form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// Stack to keep track of cloned nodes along the path,
 	// needed for purge and path compression after delete.
@@ -377,7 +377,7 @@ func (n *BartNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		// Keep track of the cloned node at current depth.
 		stack[depth] = n
 
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				// Prefix not found, nothing deleted.
@@ -468,11 +468,11 @@ func (n *BartNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
@@ -528,7 +528,7 @@ func (n *BartNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -542,9 +542,9 @@ func (n *BartNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 
 			oldVal, existed := n.GetPrefix(idx)
@@ -1877,7 +1877,7 @@ func (n *BartNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*BartNode[V]{}
@@ -1890,7 +1890,7 @@ func (n *BartNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 LOOP:
 	for depth, octet = range octets {
 		// stepped one past the last stride of interest; back up to last and exit
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -1952,9 +1952,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)
@@ -1994,14 +1994,14 @@ func (n *BartNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 			n.EachSubnet(octets, depth, is4, idx, yield)
 			return
@@ -2264,17 +2264,17 @@ func (n *BartNode[V]) OverlapsSameChildren(o *BartNode[V], depth int) bool {
 func (n *BartNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	for ; depth < len(octets); depth++ {
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			break
 		}
 
 		octet := octets[depth]
 
 		// full octet path in node trie, check overlap with last prefix octet
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.OverlapsIdx(art.PfxToIdx(octet, lastBits))
 		}
 

--- a/internal/nodes/barttestsgenerated_test.go
+++ b/internal/nodes/barttestsgenerated_test.go
@@ -1225,7 +1225,7 @@ func TestSupernetsExtra_BartNode(t *testing.T) {
 		t.Errorf("expected yieldCount 1 on backtracking early exit, got %d", yieldCount)
 	}
 
-	// 4. Trigger depth > lastOctetPlusOne
+	// 4. Trigger depth > strideCount
 	yielded = []netip.Prefix{}
 	n.Supernets(mpp("10.40.0.0/16"), func(pfx netip.Prefix, val int) bool {
 		yielded = append(yielded, pfx)

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -51,65 +51,75 @@ func (n *_NODE_TYPE[V]) LookupIdx(uint8) (_ uint8, _ V, _ bool)          { retur
 
 // ### GENERATE DELETE END ###
 
-// Insert inserts a network prefix and its associated value into the
-// trie starting at the specified byte depth.
+// Insert adds or updates a network prefix and its associated value in the trie.
+// Traversal begins at the specified byte depth.
 //
-// The function traverses the prefix address from the given depth and inserts
-// the value either directly into the node's prefix table or as a compressed
-// leaf or fringe node. If a conflicting leaf or fringe exists, it creates
-// a new intermediate node to accommodate both entries.
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// Insert resolves the collision by creating a new intermediate node, pushing
+// the existing entry down to the next level, and continuing traversal.
 //
 // Parameters:
-//   - pfx: The network prefix to insert (must be in canonical form)
-//   - val: The value to associate with the prefix
-//   - depth: The current depth in the trie (0-based byte index)
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
 //
-// Returns true if a prefix already existed and was updated, false for new insertions.
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *_NODE_TYPE[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next trie level.
+			n = kid
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(_NODE_TYPE[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -117,18 +127,17 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(_NODE_TYPE[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -142,63 +151,82 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 	panic("unreachable")
 }
 
-// InsertPersist is similar to insert but the receiver isn't modified.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// InsertPersist adds or updates a network prefix and its associated value in the trie
+// using Copy-On-Write (COW) semantics. Traversal begins at the specified byte depth.
+//
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// Unlike Insert, InsertPersist ensures structural integrity of the existing tree
+// by cloning internal nodes along the descent path (Copy-On-Write) before mutation.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// InsertPersist resolves the collision by creating a new intermediate node,
+// pushing the existing entry down to the next level, and continuing traversal.
+//
+// Parameters:
+//   - cloneFn: The function used to clone values (V).
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
+//
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *_NODE_TYPE[V]:
-			// clone the traversed path
-
-			// kid points now to cloned kid
+			// Standard intermediate node: Clone the traversed path to maintain persistence (COW).
+			// We clone the child node before modifying it, then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// replace kid with clone
 			n.InsertChild(octet, kid)
-
 			n = kid
-			continue // descend down to next trie level
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(_NODE_TYPE[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -206,18 +234,17 @@ func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(_NODE_TYPE[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -227,30 +254,31 @@ func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 		default:
 			panic("logic error, wrong node type")
 		}
-
 	}
-
 	panic("unreachable")
 }
 
-// PurgeAndCompress performs bottom-up compression of the trie.
+// PurgeAndCompress performs bottom-up trie maintenance to restore path compression
+// after a deletion. It unwinds the provided stack of parent nodes, identifying
+// nodes that have become sparse (i.e., containing only a single prefix or a single
+// child node) and prunes them by promoting the underlying entries to the parent level.
 //
-// The function unwinds the provided stack of parent nodes, checking each level
-// for compression opportunities based on child and prefix count.
-// It may convert:
-//   - Nodes with a single prefix into leaf one level above.
-//   - Nodes with a single leaf or fringe into leaf one level above.
+// This ensures the trie remains memory-efficient by collapsing redundant intermediate
+// nodes back into path-compressed LeafNodes or FringeNodes whenever possible.
 //
 // Parameters:
-//   - stack: Array of parent nodes to process during unwinding
-//   - octets: The path of octets taken to reach the current position
-//   - is4: True for IPv4 processing, false for IPv6
+//   - stack: Array of parent nodes to process during bottom-up unwinding.
+//   - octets: The full path of octets leading to the current node.
+//   - is4: True for IPv4 processing, false for IPv6.
 func (n *_NODE_TYPE[V]) PurgeAndCompress(stack []*_NODE_TYPE[V], octets []uint8, is4 bool) {
-	// unwind the stack
+	// Iterate backwards through the ancestor stack to prune nodes from the bottom up.
 	for depth := len(stack) - 1; depth >= 0; depth-- {
 		parent := stack[depth]
 		octet := octets[depth]
 
+		// Check if the current node is redundant.
+		// A node is redundant if it contains exactly one entry (either a prefix or a child node).
+		// If it contains more than one entry, it is structurally significant and cannot be pruned.
 		pfxCount := n.PrefixCount()
 		childCount := n.ChildCount()
 
@@ -260,129 +288,133 @@ func (n *_NODE_TYPE[V]) PurgeAndCompress(stack []*_NODE_TYPE[V], octets []uint8,
 
 		switch {
 		case childCount == 1:
-			singleAddr, _ := n.Children.FirstSet() // single addr must be first bit set
+			// The node has exactly one child. We determine if it is a path node,
+			// a compressed LeafNode, or a compressed FringeNode.
+			singleAddr, _ := n.Children.FirstSet()
 			anyKid := n.MustGetChild(singleAddr)
 
 			switch kid := anyKid.(type) {
 			case *_NODE_TYPE[V]:
-				// fast exit, we are at an intermediate path node
-				// no further delete/compress upwards the stack is possible
+				// The child is an intermediate path node; the tree structure is required
+				// at this level. Compression cannot proceed further up.
 				return
 			case *LeafNode[V]:
-				// just one leaf, delete this node and reinsert the leaf above
+				// The child is a compressed LeafNode. Prune the current empty node
+				// and re-insert the leaf into the parent to elevate it.
 				parent.DeleteChild(octet)
-
-				// ... (re)insert the leaf at parents depth
 				parent.Insert(kid.Prefix, kid.Value, depth)
 			case *FringeNode[V]:
-				// just one fringe, delete this node and reinsert the fringe as leaf above
+				// The child is a compressed FringeNode. Prune the current node
+				// and re-insert the fringe as a leaf into the parent.
 				parent.DeleteChild(octet)
 
-				// rebuild the prefix with octets, depth, ip version and addr
-				// depth is the parent's depth, so add +1 here for the kid
-				// lastOctet in cidrForFringe is the only addr (singleAddr)
+				// Reconstruct the full prefix for the fringe, as path compression
+				// requires the entire CIDR path, not just the remainder.
+				// depth is the parent's depth, so we offset by 1 for the kid's position.
 				fringePfx := CidrForFringe(octets, depth+1, is4, singleAddr)
 
-				// ... (re)reinsert prefix/value at parents depth
 				parent.Insert(fringePfx, kid.Value, depth)
 			}
 
 		case pfxCount == 1:
-			// just one prefix, delete this node and reinsert the idx as leaf above
+			// The node has exactly one prefix. Prune the node and elevate the
+			// prefix to the parent level as a leaf/fringe.
 			parent.DeleteChild(octet)
 
-			// get prefix back from idx ...
-			idx, _ := n.Prefixes.FirstSet() // single idx must be first bit set
+			// Retrieve the single prefix stored in this node.
+			idx, _ := n.Prefixes.FirstSet()
 			val := n.MustGetPrefix(idx)
 
-			// ... and octet path
+			// Reconstruct the prefix from the path for re-insertion.
 			path := StridePath{}
 			copy(path[:], octets)
-
-			// depth is the parent's depth, so add +1 here for the kid
 			pfx := CidrFromPath(path, depth+1, is4, idx)
 
-			// ... (re)insert prefix/value at parents depth
 			parent.Insert(pfx, val, depth)
 		}
 
-		// climb up the stack
+		// Move up to the next parent in the stack to continue pruning.
 		n = parent
 	}
 }
 
-// Delete deletes the prefix and returns true if the prefix existed,
-// or false otherwise. The prefix must be in canonical form.
+// Delete removes the prefix from the trie rooted at n and returns true if the
+// prefix existed, false if it was not found. The prefix must be in canonical
+// (masked) form.
+//
+// The trie uses path compression, so a prefix may be stored in one of three ways:
+//   - In the current node's prefix table when the prefix length aligns exactly
+//     with the stride boundary at this depth (depth == strideCount).
+//   - As a path-compressed FringeNode in a child slot for stride-aligned prefixes
+//     (e.g. /8, /16, /24); occurs at depth == strideCount-1.
+//   - As a path-compressed LeafNode in a child slot for prefixes that fall
+//     between stride boundaries.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
-	ip := pfx.Addr()
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// record the nodes on the path to the deleted node, needed to purge
-	// and/or path compress nodes after the deletion of a prefix
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
 	stack := [MaxTreeDepth]*_NODE_TYPE[V]{}
 
-	// find the trie node
 	for depth, octet := range octets {
-		depth &= DepthMask // BCE, Delete must be fast
+		depth &= DepthMask // BCE hint; keep Delete on the fast path
 
-		// push current node on stack for path recording
-		stack[depth] = n
+		stack[depth] = n // record current node before descending
 
-		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
 			}
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
 			return true
 		}
 
+		// no child node exists at this octet; the prefix is not in the trie
 		if !n.Children.Test(octet) {
 			return false
 		}
+
+		// A child node exists at this octet path, retrieve it.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf or fringe at octet
 		switch kid := kid.(type) {
 		case *_NODE_TYPE[V]:
-			n = kid // descend down to next trie level
+			n = kid // descend to the next trie level
 
 		case *FringeNode[V]:
-			// if pfx is no fringe at this depth, fast exit
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
 				return false
 			}
 
-			// pfx is fringe at depth, delete fringe
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Attention: pfx must be masked to be comparable!
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
 				return false
 			}
 
-			// prefix is equal leaf, delete leaf
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
@@ -393,142 +425,148 @@ func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 	panic("unreachable")
 }
 
-// DeletePersist is similar to delete but does not mutate the original trie.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// DeletePersist removes the prefix from the trie rooted at n using Copy-On-Write (COW) semantics.
+// It returns true if the prefix existed, false if it was not found. The prefix must be in
+// canonical (masked) form.
+//
+// Like Delete, this method uses path compression. However, DeletePersist ensures
+// the structural integrity of the existing tree by cloning internal nodes along the
+// descent path (COW) before mutation.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
-	ip := pfx.Addr() // the pfx must be in canonical form
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// Stack to keep track of cloned nodes along the path,
-	// needed for purge and path compression after delete.
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
+	// Since this is a COW operation, we store the cloned nodes here.
 	stack := [MaxTreeDepth]*_NODE_TYPE[V]{}
 
-	// Traverse the trie to locate the prefix to delete.
 	for depth, octet := range octets {
-		// Keep track of the cloned node at current depth.
-		stack[depth] = n
+		depth &= DepthMask // BCE hint; keep DeletePersist on the fast path
+		stack[depth] = n   // record current node before descending
 
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
-				// Prefix not found, nothing deleted.
 				return false
 			}
 
-			// After deletion, purge nodes and compress the path if needed.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 		}
 
-		addr := octet
-
-		// If child node doesn't exist, no prefix to delete.
-		if !n.Children.Test(addr) {
+		// no child node exists at this octet; the prefix is not in the trie
+		if !n.Children.Test(octet) {
 			return false
 		}
 
-		// Fetch child node at current address.
-		kid := n.MustGetChild(addr)
+		// A child node exists at this octet path, retrieve it to either continue
+		// our descent or perform a persistent delete on a compressed node.
+		kid := n.MustGetChild(octet)
 
 		switch kid := kid.(type) {
 		case *_NODE_TYPE[V]:
-			// Clone the internal node for copy-on-write.
+			// Standard intermediate node: Clone the traversed path to maintain
+			// persistence (COW). We clone the child node before modifying it,
+			// then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// Replace child with cloned node.
-			n.InsertChild(addr, kid)
-
-			// Descend to cloned child node.
+			n.InsertChild(octet, kid)
 			n = kid
 			continue
 
 		case *FringeNode[V]:
-			// Reached a path compressed fringe.
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
-				// Prefix to delete not found here.
 				return false
 			}
 
-			// Delete the fringe node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Reached a path compressed leaf node.
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
-				// Leaf prefix does not match; nothing to delete.
 				return false
 			}
 
-			// Delete leaf node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
-			// Unexpected node type indicates a logic error.
 			panic("logic error, wrong node type")
 		}
 	}
 
-	// Should never happen: traversal always returns or panics inside loop.
 	panic("unreachable")
 }
 
 // Get retrieves the value associated with the given network prefix.
-// Returns the stored value and true if the prefix exists in this node,
-// zero value and false if the prefix is not found.
+// Traversal descends through the trie using the prefix's octets.
+//
+// The lookup handles path compression transparently:
+//   - If the path matches an internal node at the target stride, the value is retrieved
+//     from the node's prefix table.
+//   - If the path leads to a compressed LeafNode or FringeNode, the function verifies
+//     the prefix match before returning the value.
 //
 // Parameters:
-//   - pfx: The network prefix to look up (must be in canonical form)
+//   - pfx: The network prefix to look up (must be in canonical form).
 //
 // Returns:
-//   - val: The value associated with the prefix (zero value if not found)
-//   - exists: True if the prefix was found, false otherwise
+//   - val: The value associated with the prefix (zero value if not found).
+//   - exists: True if the prefix was found, false otherwise.
 func (n *_NODE_TYPE[V]) Get(pfx netip.Prefix) (val V, exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
+	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the trie node
+	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
+		// At the target stride boundary, the prefix is expected in this node's
+		// prefix table.
 		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
+		// If no child exists at this path, the prefix is not in the trie.
 		kidAny, ok := n.GetChild(octet)
 		if !ok {
 			return val, false
 		}
 
-		// kid is node or leaf or fringe at octet
+		// Identify the node type at this path segment.
 		switch kid := kidAny.(type) {
 		case *_NODE_TYPE[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next level.
+			n = kid
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe, stop traversing
+			// Reached a path-compressed FringeNode.
+			// Verify if the prefix qualifies as a fringe at this depth to return a match.
 			if IsFringe(depth, pfx) {
 				return kid.Value, true
 			}
 			return val, false
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix, stop traversing
+			// Reached a path-compressed LeafNode.
+			// Check if the stored prefix matches the lookup prefix exactly.
 			if kid.Prefix == pfx {
 				return kid.Value, true
 			}
@@ -546,7 +584,7 @@ func (n *_NODE_TYPE[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 // The callback receives the current value (if found) and existence flag, and returns
 // a new value and deletion flag.
 //
-// modify returns the size delta (-1, 0, +1).
+// Modify returns the size delta (-1, 0, +1).
 // This method handles path traversal, node creation for new paths, and automatic
 // purge/compress operations after deletions.
 //
@@ -808,8 +846,8 @@ func (n *_NODE_TYPE[V]) EqualRec(o *_NODE_TYPE[V]) bool {
 //
 // It returns immediately if n is nil or empty. For each visited internal node
 // it calls dump to write the node's representation, then iterates its child
-// addresses and recurses into children that implement nodeDumper[V] (internal
-// subnodes). The path slice and depth together represent the byte-wise path
+// addresses and recurses into children of type *_NODE_TYPE[V] (internal subnodes).
+// The path slice and depth together represent the byte-wise path
 // from the root to the current node; depth is incremented for each recursion.
 // The is4 flag controls IPv4/IPv6 formatting used by dump.
 func (n *_NODE_TYPE[V]) DumpRec(w io.Writer, path StridePath, depth int, is4 bool) {
@@ -1001,7 +1039,7 @@ func (n *_NODE_TYPE[V]) DumpString(octets []uint8, depth int, is4 bool) string {
 //   - stopNode: has children but no subnodes (nodes == 0)
 //   - halfNode: contains at least one leaf or fringe and also has subnodes, but
 //     no prefixes
-//   - fullNode: has prefixes or leaves/fringes and also has subnodes
+//   - fullNode: has prefixes and also has subnodes
 //   - pathNode: has subnodes only (no prefixes, leaves, or fringes)
 //
 // The order of these checks is significant to ensure the correct classification.
@@ -1058,7 +1096,7 @@ func (n *_NODE_TYPE[V]) Stats() (s StatsT) {
 // It walks the node tree recursively and sums immediate counts (prefixes and
 // child slots) plus the number of nodes, leaves, and fringe nodes in the
 // subtree. If n is nil or empty, a zeroed stats is returned. The returned
-// stats.nodes includes the current node. The function will panic if a child
+// SubNodes count includes the current node. The function will panic if a child
 // has an unexpected concrete type.
 func (n *_NODE_TYPE[V]) StatsRec() (s StatsT) {
 	if n == nil || n.IsEmpty() {
@@ -1212,7 +1250,7 @@ func (n *_NODE_TYPE[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth i
 				path[depth] = addr
 				directItems = append(directItems, kid.DirectItemsRec(0, path, depth+1, is4)...)
 
-			case *LeafNode[V]: // path-compressed child, stop's recursion for this child
+			case *LeafNode[V]: // path-compressed child, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1221,7 +1259,7 @@ func (n *_NODE_TYPE[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth i
 				}
 				directItems = append(directItems, item)
 
-			case *FringeNode[V]: // path-compressed fringe, stop's recursion for this child
+			case *FringeNode[V]: // path-compressed fringe, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1985,9 +2023,8 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
@@ -2032,7 +2069,7 @@ func (n *_NODE_TYPE[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 
 	// find the trie node
 	for depth, octet := range octets {
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
@@ -2154,7 +2191,7 @@ func (n *_NODE_TYPE[V]) Overlaps(o *_NODE_TYPE[V], depth int) bool {
 // OverlapsRoutes compares the prefix sets of two nodes (n and o).
 //
 // It first checks for direct bitset intersection (identical indices),
-// then walks both prefix sets using lpmTest to detect if any
+// then walks both prefix sets using the Contains method to detect if any
 // of the n-prefixes is contained in o, or vice versa.
 func (n *_NODE_TYPE[V]) OverlapsRoutes(o *_NODE_TYPE[V]) bool {
 	// some prefixes are identical, trivial overlap

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -71,8 +71,9 @@ func (n *_NODE_TYPE[V]) LookupIdx(uint8) (_ uint8, _ V, _ bool)          { retur
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -92,7 +93,7 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -129,7 +130,7 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -175,8 +176,9 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -196,7 +198,7 @@ func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -236,7 +238,7 @@ func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -354,9 +356,10 @@ func (n *_NODE_TYPE[V]) PurgeAndCompress(stack []*_NODE_TYPE[V], octets []uint8,
 // now-empty nodes and restore path compression upward.
 func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -394,7 +397,7 @@ func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -437,9 +440,10 @@ func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 // now-empty nodes and restore path compression upward.
 func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -484,7 +488,7 @@ func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -533,8 +537,9 @@ func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 func (n *_NODE_TYPE[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
@@ -559,7 +564,7 @@ func (n *_NODE_TYPE[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 		case *FringeNode[V]:
 			// Reached a path-compressed FringeNode.
 			// Verify if the prefix qualifies as a fringe at this depth to return a match.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return kid.Value, true
 			}
 			return val, false
@@ -598,9 +603,10 @@ func (n *_NODE_TYPE[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V
 	var zero V
 
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -657,7 +663,7 @@ func (n *_NODE_TYPE[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V
 			}
 
 			// insert
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				n.InsertChild(octet, NewFringeNode(newVal))
 			} else {
 				n.InsertChild(octet, NewLeafNode(pfx, newVal))
@@ -716,7 +722,7 @@ func (n *_NODE_TYPE[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V
 
 		case *FringeNode[V]:
 			// update existing value if prefix is fringe
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				newVal, del := cb(kid.Value, true)
 				if !del {
 					kid.Value = newVal
@@ -1947,9 +1953,10 @@ func (n *_NODE_TYPE[V]) EachSubnet(octets []byte, depth int, is4 bool, pfxIdx ui
 // the iteration early.
 func (n *_NODE_TYPE[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*_NODE_TYPE[V]{}
@@ -2063,9 +2070,10 @@ LOOP:
 func (n *_NODE_TYPE[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// find the trie node
 	for depth, octet := range octets {
@@ -2334,8 +2342,9 @@ func (n *_NODE_TYPE[V]) OverlapsSameChildren(o *_NODE_TYPE[V], depth int) bool {
 // trie traversal across varying prefix lengths and compression levels.
 func (n *_NODE_TYPE[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	for ; depth < len(octets); depth++ {
 		if depth > strideCount {

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -68,7 +68,7 @@ func (n *_NODE_TYPE[V]) LookupIdx(uint8) (_ uint8, _ V, _ bool)          { retur
 func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -76,7 +76,7 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -148,7 +148,7 @@ func (n *_NODE_TYPE[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool)
 func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -156,7 +156,7 @@ func (n *_NODE_TYPE[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -320,7 +320,7 @@ func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -334,9 +334,9 @@ func (n *_NODE_TYPE[V]) Delete(pfx netip.Prefix) (exists bool) {
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
@@ -400,7 +400,7 @@ func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 	ip := pfx.Addr() // the pfx must be in canonical form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// Stack to keep track of cloned nodes along the path,
 	// needed for purge and path compression after delete.
@@ -411,7 +411,7 @@ func (n *_NODE_TYPE[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Pref
 		// Keep track of the cloned node at current depth.
 		stack[depth] = n
 
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				// Prefix not found, nothing deleted.
@@ -502,11 +502,11 @@ func (n *_NODE_TYPE[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
@@ -562,7 +562,7 @@ func (n *_NODE_TYPE[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -576,9 +576,9 @@ func (n *_NODE_TYPE[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 
 			oldVal, existed := n.GetPrefix(idx)
@@ -1911,7 +1911,7 @@ func (n *_NODE_TYPE[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) 
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*_NODE_TYPE[V]{}
@@ -1924,7 +1924,7 @@ func (n *_NODE_TYPE[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) 
 LOOP:
 	for depth, octet = range octets {
 		// stepped one past the last stride of interest; back up to last and exit
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -1986,9 +1986,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)
@@ -2028,14 +2028,14 @@ func (n *_NODE_TYPE[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 			n.EachSubnet(octets, depth, is4, idx, yield)
 			return
@@ -2298,17 +2298,17 @@ func (n *_NODE_TYPE[V]) OverlapsSameChildren(o *_NODE_TYPE[V], depth int) bool {
 func (n *_NODE_TYPE[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	for ; depth < len(octets); depth++ {
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			break
 		}
 
 		octet := octets[depth]
 
 		// full octet path in node trie, check overlap with last prefix octet
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.OverlapsIdx(art.PfxToIdx(octet, lastBits))
 		}
 

--- a/internal/nodes/commontests_tmpl.go
+++ b/internal/nodes/commontests_tmpl.go
@@ -1254,7 +1254,7 @@ func TestSupernetsExtra__NODE_TYPE(t *testing.T) {
 		t.Errorf("expected yieldCount 1 on backtracking early exit, got %d", yieldCount)
 	}
 
-	// 4. Trigger depth > lastOctetPlusOne
+	// 4. Trigger depth > strideCount
 	yielded = []netip.Prefix{}
 	n.Supernets(mpp("10.40.0.0/16"), func(pfx netip.Prefix, val int) bool {
 		yielded = append(yielded, pfx)

--- a/internal/nodes/fast.go
+++ b/internal/nodes/fast.go
@@ -11,27 +11,11 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// Each FastNode contains three conceptually different arrays:
-//
-//   - Prefixes stores routing entries (prefix -> value),
-//     laid out as a complete binary tree using the baseIndex()
-//     function from the ART algorithm.
-//
-//   - Children: holding subtries or path-compressed leaves/fringes with
-//     a branching factor of 256 (8 bits per stride).
-//
-//   - childRankCache for cached rank values for fast trie traversal.
-//
-// Entries in Children may be:
-//   - *FastNode[V]   -> internal child node for further traversal
-//   - *LeafNode[V]   -> path-comp. node (depth < maxDepth - 1)
-//   - *FringeNode[V] -> path-comp. node (depth == maxDepth - 1, stride-aligned: /8, /16, ... /128)
-//
 // FastNode is based on [BartNode], but it also uses a cache ([256]uint8)
-// per node to speed up traversal of the multi-bit trie. Lookups become
-// faster, but this requires more memory per prefix,
-// and updates (insertions/deletions) also become slower due to the overhead
-// of managing the cache.
+// per node to speed up traversal of the multi-bit trie.
+// Lookups become faster, but this requires more memory per prefix,
+// and updates (insertions/deletions) also become slower due to the
+// overhead of managing the cache.
 type FastNode[V any] struct {
 	Prefixes sparse.Array256[V]
 	Children sparse.Array256[any]

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -17,65 +17,75 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// Insert inserts a network prefix and its associated value into the
-// trie starting at the specified byte depth.
+// Insert adds or updates a network prefix and its associated value in the trie.
+// Traversal begins at the specified byte depth.
 //
-// The function traverses the prefix address from the given depth and inserts
-// the value either directly into the node's prefix table or as a compressed
-// leaf or fringe node. If a conflicting leaf or fringe exists, it creates
-// a new intermediate node to accommodate both entries.
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// Insert resolves the collision by creating a new intermediate node, pushing
+// the existing entry down to the next level, and continuing traversal.
 //
 // Parameters:
-//   - pfx: The network prefix to insert (must be in canonical form)
-//   - val: The value to associate with the prefix
-//   - depth: The current depth in the trie (0-based byte index)
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
 //
-// Returns true if a prefix already existed and was updated, false for new insertions.
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *FastNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next trie level.
+			n = kid
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(FastNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -83,18 +93,17 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(FastNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -108,63 +117,82 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	panic("unreachable")
 }
 
-// InsertPersist is similar to insert but the receiver isn't modified.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// InsertPersist adds or updates a network prefix and its associated value in the trie
+// using Copy-On-Write (COW) semantics. Traversal begins at the specified byte depth.
+//
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// Unlike Insert, InsertPersist ensures structural integrity of the existing tree
+// by cloning internal nodes along the descent path (Copy-On-Write) before mutation.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// InsertPersist resolves the collision by creating a new intermediate node,
+// pushing the existing entry down to the next level, and continuing traversal.
+//
+// Parameters:
+//   - cloneFn: The function used to clone values (V).
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
+//
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *FastNode[V]:
-			// clone the traversed path
-
-			// kid points now to cloned kid
+			// Standard intermediate node: Clone the traversed path to maintain persistence (COW).
+			// We clone the child node before modifying it, then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// replace kid with clone
 			n.InsertChild(octet, kid)
-
 			n = kid
-			continue // descend down to next trie level
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(FastNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -172,18 +200,17 @@ func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(FastNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -193,30 +220,31 @@ func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		default:
 			panic("logic error, wrong node type")
 		}
-
 	}
-
 	panic("unreachable")
 }
 
-// PurgeAndCompress performs bottom-up compression of the trie.
+// PurgeAndCompress performs bottom-up trie maintenance to restore path compression
+// after a deletion. It unwinds the provided stack of parent nodes, identifying
+// nodes that have become sparse (i.e., containing only a single prefix or a single
+// child node) and prunes them by promoting the underlying entries to the parent level.
 //
-// The function unwinds the provided stack of parent nodes, checking each level
-// for compression opportunities based on child and prefix count.
-// It may convert:
-//   - Nodes with a single prefix into leaf one level above.
-//   - Nodes with a single leaf or fringe into leaf one level above.
+// This ensures the trie remains memory-efficient by collapsing redundant intermediate
+// nodes back into path-compressed LeafNodes or FringeNodes whenever possible.
 //
 // Parameters:
-//   - stack: Array of parent nodes to process during unwinding
-//   - octets: The path of octets taken to reach the current position
-//   - is4: True for IPv4 processing, false for IPv6
+//   - stack: Array of parent nodes to process during bottom-up unwinding.
+//   - octets: The full path of octets leading to the current node.
+//   - is4: True for IPv4 processing, false for IPv6.
 func (n *FastNode[V]) PurgeAndCompress(stack []*FastNode[V], octets []uint8, is4 bool) {
-	// unwind the stack
+	// Iterate backwards through the ancestor stack to prune nodes from the bottom up.
 	for depth := len(stack) - 1; depth >= 0; depth-- {
 		parent := stack[depth]
 		octet := octets[depth]
 
+		// Check if the current node is redundant.
+		// A node is redundant if it contains exactly one entry (either a prefix or a child node).
+		// If it contains more than one entry, it is structurally significant and cannot be pruned.
 		pfxCount := n.PrefixCount()
 		childCount := n.ChildCount()
 
@@ -226,129 +254,133 @@ func (n *FastNode[V]) PurgeAndCompress(stack []*FastNode[V], octets []uint8, is4
 
 		switch {
 		case childCount == 1:
-			singleAddr, _ := n.Children.FirstSet() // single addr must be first bit set
+			// The node has exactly one child. We determine if it is a path node,
+			// a compressed LeafNode, or a compressed FringeNode.
+			singleAddr, _ := n.Children.FirstSet()
 			anyKid := n.MustGetChild(singleAddr)
 
 			switch kid := anyKid.(type) {
 			case *FastNode[V]:
-				// fast exit, we are at an intermediate path node
-				// no further delete/compress upwards the stack is possible
+				// The child is an intermediate path node; the tree structure is required
+				// at this level. Compression cannot proceed further up.
 				return
 			case *LeafNode[V]:
-				// just one leaf, delete this node and reinsert the leaf above
+				// The child is a compressed LeafNode. Prune the current empty node
+				// and re-insert the leaf into the parent to elevate it.
 				parent.DeleteChild(octet)
-
-				// ... (re)insert the leaf at parents depth
 				parent.Insert(kid.Prefix, kid.Value, depth)
 			case *FringeNode[V]:
-				// just one fringe, delete this node and reinsert the fringe as leaf above
+				// The child is a compressed FringeNode. Prune the current node
+				// and re-insert the fringe as a leaf into the parent.
 				parent.DeleteChild(octet)
 
-				// rebuild the prefix with octets, depth, ip version and addr
-				// depth is the parent's depth, so add +1 here for the kid
-				// lastOctet in cidrForFringe is the only addr (singleAddr)
+				// Reconstruct the full prefix for the fringe, as path compression
+				// requires the entire CIDR path, not just the remainder.
+				// depth is the parent's depth, so we offset by 1 for the kid's position.
 				fringePfx := CidrForFringe(octets, depth+1, is4, singleAddr)
 
-				// ... (re)reinsert prefix/value at parents depth
 				parent.Insert(fringePfx, kid.Value, depth)
 			}
 
 		case pfxCount == 1:
-			// just one prefix, delete this node and reinsert the idx as leaf above
+			// The node has exactly one prefix. Prune the node and elevate the
+			// prefix to the parent level as a leaf/fringe.
 			parent.DeleteChild(octet)
 
-			// get prefix back from idx ...
-			idx, _ := n.Prefixes.FirstSet() // single idx must be first bit set
+			// Retrieve the single prefix stored in this node.
+			idx, _ := n.Prefixes.FirstSet()
 			val := n.MustGetPrefix(idx)
 
-			// ... and octet path
+			// Reconstruct the prefix from the path for re-insertion.
 			path := StridePath{}
 			copy(path[:], octets)
-
-			// depth is the parent's depth, so add +1 here for the kid
 			pfx := CidrFromPath(path, depth+1, is4, idx)
 
-			// ... (re)insert prefix/value at parents depth
 			parent.Insert(pfx, val, depth)
 		}
 
-		// climb up the stack
+		// Move up to the next parent in the stack to continue pruning.
 		n = parent
 	}
 }
 
-// Delete deletes the prefix and returns true if the prefix existed,
-// or false otherwise. The prefix must be in canonical form.
+// Delete removes the prefix from the trie rooted at n and returns true if the
+// prefix existed, false if it was not found. The prefix must be in canonical
+// (masked) form.
+//
+// The trie uses path compression, so a prefix may be stored in one of three ways:
+//   - In the current node's prefix table when the prefix length aligns exactly
+//     with the stride boundary at this depth (depth == strideCount).
+//   - As a path-compressed FringeNode in a child slot for stride-aligned prefixes
+//     (e.g. /8, /16, /24); occurs at depth == strideCount-1.
+//   - As a path-compressed LeafNode in a child slot for prefixes that fall
+//     between stride boundaries.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
-	ip := pfx.Addr()
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// record the nodes on the path to the deleted node, needed to purge
-	// and/or path compress nodes after the deletion of a prefix
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
 	stack := [MaxTreeDepth]*FastNode[V]{}
 
-	// find the trie node
 	for depth, octet := range octets {
-		depth &= DepthMask // BCE, Delete must be fast
+		depth &= DepthMask // BCE hint; keep Delete on the fast path
 
-		// push current node on stack for path recording
-		stack[depth] = n
+		stack[depth] = n // record current node before descending
 
-		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
 			}
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
 			return true
 		}
 
+		// no child node exists at this octet; the prefix is not in the trie
 		if !n.Children.Test(octet) {
 			return false
 		}
+
+		// A child node exists at this octet path, retrieve it.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf or fringe at octet
 		switch kid := kid.(type) {
 		case *FastNode[V]:
-			n = kid // descend down to next trie level
+			n = kid // descend to the next trie level
 
 		case *FringeNode[V]:
-			// if pfx is no fringe at this depth, fast exit
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
 				return false
 			}
 
-			// pfx is fringe at depth, delete fringe
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Attention: pfx must be masked to be comparable!
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
 				return false
 			}
 
-			// prefix is equal leaf, delete leaf
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
@@ -359,142 +391,148 @@ func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	panic("unreachable")
 }
 
-// DeletePersist is similar to delete but does not mutate the original trie.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// DeletePersist removes the prefix from the trie rooted at n using Copy-On-Write (COW) semantics.
+// It returns true if the prefix existed, false if it was not found. The prefix must be in
+// canonical (masked) form.
+//
+// Like Delete, this method uses path compression. However, DeletePersist ensures
+// the structural integrity of the existing tree by cloning internal nodes along the
+// descent path (COW) before mutation.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
-	ip := pfx.Addr() // the pfx must be in canonical form
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// Stack to keep track of cloned nodes along the path,
-	// needed for purge and path compression after delete.
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
+	// Since this is a COW operation, we store the cloned nodes here.
 	stack := [MaxTreeDepth]*FastNode[V]{}
 
-	// Traverse the trie to locate the prefix to delete.
 	for depth, octet := range octets {
-		// Keep track of the cloned node at current depth.
-		stack[depth] = n
+		depth &= DepthMask // BCE hint; keep DeletePersist on the fast path
+		stack[depth] = n   // record current node before descending
 
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
-				// Prefix not found, nothing deleted.
 				return false
 			}
 
-			// After deletion, purge nodes and compress the path if needed.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 		}
 
-		addr := octet
-
-		// If child node doesn't exist, no prefix to delete.
-		if !n.Children.Test(addr) {
+		// no child node exists at this octet; the prefix is not in the trie
+		if !n.Children.Test(octet) {
 			return false
 		}
 
-		// Fetch child node at current address.
-		kid := n.MustGetChild(addr)
+		// A child node exists at this octet path, retrieve it to either continue
+		// our descent or perform a persistent delete on a compressed node.
+		kid := n.MustGetChild(octet)
 
 		switch kid := kid.(type) {
 		case *FastNode[V]:
-			// Clone the internal node for copy-on-write.
+			// Standard intermediate node: Clone the traversed path to maintain
+			// persistence (COW). We clone the child node before modifying it,
+			// then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// Replace child with cloned node.
-			n.InsertChild(addr, kid)
-
-			// Descend to cloned child node.
+			n.InsertChild(octet, kid)
 			n = kid
 			continue
 
 		case *FringeNode[V]:
-			// Reached a path compressed fringe.
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
-				// Prefix to delete not found here.
 				return false
 			}
 
-			// Delete the fringe node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Reached a path compressed leaf node.
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
-				// Leaf prefix does not match; nothing to delete.
 				return false
 			}
 
-			// Delete leaf node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
-			// Unexpected node type indicates a logic error.
 			panic("logic error, wrong node type")
 		}
 	}
 
-	// Should never happen: traversal always returns or panics inside loop.
 	panic("unreachable")
 }
 
 // Get retrieves the value associated with the given network prefix.
-// Returns the stored value and true if the prefix exists in this node,
-// zero value and false if the prefix is not found.
+// Traversal descends through the trie using the prefix's octets.
+//
+// The lookup handles path compression transparently:
+//   - If the path matches an internal node at the target stride, the value is retrieved
+//     from the node's prefix table.
+//   - If the path leads to a compressed LeafNode or FringeNode, the function verifies
+//     the prefix match before returning the value.
 //
 // Parameters:
-//   - pfx: The network prefix to look up (must be in canonical form)
+//   - pfx: The network prefix to look up (must be in canonical form).
 //
 // Returns:
-//   - val: The value associated with the prefix (zero value if not found)
-//   - exists: True if the prefix was found, false otherwise
+//   - val: The value associated with the prefix (zero value if not found).
+//   - exists: True if the prefix was found, false otherwise.
 func (n *FastNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
+	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the trie node
+	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
+		// At the target stride boundary, the prefix is expected in this node's
+		// prefix table.
 		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
+		// If no child exists at this path, the prefix is not in the trie.
 		kidAny, ok := n.GetChild(octet)
 		if !ok {
 			return val, false
 		}
 
-		// kid is node or leaf or fringe at octet
+		// Identify the node type at this path segment.
 		switch kid := kidAny.(type) {
 		case *FastNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next level.
+			n = kid
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe, stop traversing
+			// Reached a path-compressed FringeNode.
+			// Verify if the prefix qualifies as a fringe at this depth to return a match.
 			if IsFringe(depth, pfx) {
 				return kid.Value, true
 			}
 			return val, false
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix, stop traversing
+			// Reached a path-compressed LeafNode.
+			// Check if the stored prefix matches the lookup prefix exactly.
 			if kid.Prefix == pfx {
 				return kid.Value, true
 			}
@@ -512,7 +550,7 @@ func (n *FastNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 // The callback receives the current value (if found) and existence flag, and returns
 // a new value and deletion flag.
 //
-// modify returns the size delta (-1, 0, +1).
+// Modify returns the size delta (-1, 0, +1).
 // This method handles path traversal, node creation for new paths, and automatic
 // purge/compress operations after deletions.
 //
@@ -774,8 +812,8 @@ func (n *FastNode[V]) EqualRec(o *FastNode[V]) bool {
 //
 // It returns immediately if n is nil or empty. For each visited internal node
 // it calls dump to write the node's representation, then iterates its child
-// addresses and recurses into children that implement nodeDumper[V] (internal
-// subnodes). The path slice and depth together represent the byte-wise path
+// addresses and recurses into children of type *FastNode[V] (internal subnodes).
+// The path slice and depth together represent the byte-wise path
 // from the root to the current node; depth is incremented for each recursion.
 // The is4 flag controls IPv4/IPv6 formatting used by dump.
 func (n *FastNode[V]) DumpRec(w io.Writer, path StridePath, depth int, is4 bool) {
@@ -967,7 +1005,7 @@ func (n *FastNode[V]) DumpString(octets []uint8, depth int, is4 bool) string {
 //   - stopNode: has children but no subnodes (nodes == 0)
 //   - halfNode: contains at least one leaf or fringe and also has subnodes, but
 //     no prefixes
-//   - fullNode: has prefixes or leaves/fringes and also has subnodes
+//   - fullNode: has prefixes and also has subnodes
 //   - pathNode: has subnodes only (no prefixes, leaves, or fringes)
 //
 // The order of these checks is significant to ensure the correct classification.
@@ -1024,7 +1062,7 @@ func (n *FastNode[V]) Stats() (s StatsT) {
 // It walks the node tree recursively and sums immediate counts (prefixes and
 // child slots) plus the number of nodes, leaves, and fringe nodes in the
 // subtree. If n is nil or empty, a zeroed stats is returned. The returned
-// stats.nodes includes the current node. The function will panic if a child
+// SubNodes count includes the current node. The function will panic if a child
 // has an unexpected concrete type.
 func (n *FastNode[V]) StatsRec() (s StatsT) {
 	if n == nil || n.IsEmpty() {
@@ -1178,7 +1216,7 @@ func (n *FastNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				path[depth] = addr
 				directItems = append(directItems, kid.DirectItemsRec(0, path, depth+1, is4)...)
 
-			case *LeafNode[V]: // path-compressed child, stop's recursion for this child
+			case *LeafNode[V]: // path-compressed child, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1187,7 +1225,7 @@ func (n *FastNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				}
 				directItems = append(directItems, item)
 
-			case *FringeNode[V]: // path-compressed fringe, stop's recursion for this child
+			case *FringeNode[V]: // path-compressed fringe, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1951,9 +1989,8 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
@@ -1998,7 +2035,7 @@ func (n *FastNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 
 	// find the trie node
 	for depth, octet := range octets {
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
@@ -2120,7 +2157,7 @@ func (n *FastNode[V]) Overlaps(o *FastNode[V], depth int) bool {
 // OverlapsRoutes compares the prefix sets of two nodes (n and o).
 //
 // It first checks for direct bitset intersection (identical indices),
-// then walks both prefix sets using lpmTest to detect if any
+// then walks both prefix sets using the Contains method to detect if any
 // of the n-prefixes is contained in o, or vice versa.
 func (n *FastNode[V]) OverlapsRoutes(o *FastNode[V]) bool {
 	// some prefixes are identical, trivial overlap

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -37,8 +37,9 @@ import (
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -58,7 +59,7 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -95,7 +96,7 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -141,8 +142,9 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -162,7 +164,7 @@ func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -202,7 +204,7 @@ func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -320,9 +322,10 @@ func (n *FastNode[V]) PurgeAndCompress(stack []*FastNode[V], octets []uint8, is4
 // now-empty nodes and restore path compression upward.
 func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -360,7 +363,7 @@ func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -403,9 +406,10 @@ func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 // now-empty nodes and restore path compression upward.
 func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -450,7 +454,7 @@ func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -499,8 +503,9 @@ func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 func (n *FastNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
@@ -525,7 +530,7 @@ func (n *FastNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 		case *FringeNode[V]:
 			// Reached a path-compressed FringeNode.
 			// Verify if the prefix qualifies as a fringe at this depth to return a match.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return kid.Value, true
 			}
 			return val, false
@@ -564,9 +569,10 @@ func (n *FastNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	var zero V
 
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -623,7 +629,7 @@ func (n *FastNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 			}
 
 			// insert
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				n.InsertChild(octet, NewFringeNode(newVal))
 			} else {
 				n.InsertChild(octet, NewLeafNode(pfx, newVal))
@@ -682,7 +688,7 @@ func (n *FastNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 
 		case *FringeNode[V]:
 			// update existing value if prefix is fringe
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				newVal, del := cb(kid.Value, true)
 				if !del {
 					kid.Value = newVal
@@ -1913,9 +1919,10 @@ func (n *FastNode[V]) EachSubnet(octets []byte, depth int, is4 bool, pfxIdx uint
 // the iteration early.
 func (n *FastNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*FastNode[V]{}
@@ -2029,9 +2036,10 @@ LOOP:
 func (n *FastNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// find the trie node
 	for depth, octet := range octets {
@@ -2300,8 +2308,9 @@ func (n *FastNode[V]) OverlapsSameChildren(o *FastNode[V], depth int) bool {
 // trie traversal across varying prefix lengths and compression levels.
 func (n *FastNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	for ; depth < len(octets); depth++ {
 		if depth > strideCount {

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -34,7 +34,7 @@ import (
 func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -42,7 +42,7 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -114,7 +114,7 @@ func (n *FastNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -122,7 +122,7 @@ func (n *FastNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -286,7 +286,7 @@ func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -300,9 +300,9 @@ func (n *FastNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
@@ -366,7 +366,7 @@ func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 	ip := pfx.Addr() // the pfx must be in canonical form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// Stack to keep track of cloned nodes along the path,
 	// needed for purge and path compression after delete.
@@ -377,7 +377,7 @@ func (n *FastNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		// Keep track of the cloned node at current depth.
 		stack[depth] = n
 
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				// Prefix not found, nothing deleted.
@@ -468,11 +468,11 @@ func (n *FastNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
@@ -528,7 +528,7 @@ func (n *FastNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -542,9 +542,9 @@ func (n *FastNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 
 			oldVal, existed := n.GetPrefix(idx)
@@ -1877,7 +1877,7 @@ func (n *FastNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*FastNode[V]{}
@@ -1890,7 +1890,7 @@ func (n *FastNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 LOOP:
 	for depth, octet = range octets {
 		// stepped one past the last stride of interest; back up to last and exit
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -1952,9 +1952,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)
@@ -1994,14 +1994,14 @@ func (n *FastNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 			n.EachSubnet(octets, depth, is4, idx, yield)
 			return
@@ -2264,17 +2264,17 @@ func (n *FastNode[V]) OverlapsSameChildren(o *FastNode[V], depth int) bool {
 func (n *FastNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	for ; depth < len(octets); depth++ {
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			break
 		}
 
 		octet := octets[depth]
 
 		// full octet path in node trie, check overlap with last prefix octet
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.OverlapsIdx(art.PfxToIdx(octet, lastBits))
 		}
 

--- a/internal/nodes/fasttestsgenerated_test.go
+++ b/internal/nodes/fasttestsgenerated_test.go
@@ -1225,7 +1225,7 @@ func TestSupernetsExtra_FastNode(t *testing.T) {
 		t.Errorf("expected yieldCount 1 on backtracking early exit, got %d", yieldCount)
 	}
 
-	// 4. Trigger depth > lastOctetPlusOne
+	// 4. Trigger depth > strideCount
 	yielded = []netip.Prefix{}
 	n.Supernets(mpp("10.40.0.0/16"), func(pfx netip.Prefix, val int) bool {
 		yielded = append(yielded, pfx)

--- a/internal/nodes/lite.go
+++ b/internal/nodes/lite.go
@@ -12,26 +12,15 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// LiteNode is a trie level node in the multibit routing table.
-//
-// Each LiteNode contains two conceptually different bitset-based arrays:
-//   - Prefixes: a BitSet256 tracking which prefix indices are occupied,
-//     with Count tracking the number of active entries.
-//   - Children: holding subtries or path-compressed leaves/fringes with
-//     a branching factor of 256 (8 bits per stride).
-//
-// Entries in Children may be:
-//   - *LiteNode[V]   -> internal child node for further traversal
-//   - *LeafNode[V]   -> path-comp. node (depth < maxDepth - 1)
-//   - *FringeNode[V] -> path-comp. node (depth == maxDepth - 1, stride-aligned)
-//
-// Note: The type parameter V is a phantom type used solely for common
-// method generation; LiteNode stores no values.
+// LiteNode is a space-optimized version of [BartNode] that tracks prefix existence
+// without storing associated values.
 type LiteNode[V any] struct {
 	Children sparse.Array256[any]
 	Prefixes struct {
-		// no values
+		// BitSet256 tracks the presence of prefixes at this level.
 		bitset.BitSet256
+		// Count maintains the current number of set bits, updated on modification
+		// to avoid redundant population counting.
 		Count uint16
 	}
 }

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -17,65 +17,75 @@ import (
 	"github.com/gaissmai/bart/internal/value"
 )
 
-// Insert inserts a network prefix and its associated value into the
-// trie starting at the specified byte depth.
+// Insert adds or updates a network prefix and its associated value in the trie.
+// Traversal begins at the specified byte depth.
 //
-// The function traverses the prefix address from the given depth and inserts
-// the value either directly into the node's prefix table or as a compressed
-// leaf or fringe node. If a conflicting leaf or fringe exists, it creates
-// a new intermediate node to accommodate both entries.
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// Insert resolves the collision by creating a new intermediate node, pushing
+// the existing entry down to the next level, and continuing traversal.
 //
 // Parameters:
-//   - pfx: The network prefix to insert (must be in canonical form)
-//   - val: The value to associate with the prefix
-//   - depth: The current depth in the trie (0-based byte index)
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
 //
-// Returns true if a prefix already existed and was updated, false for new insertions.
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *LiteNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next trie level.
+			n = kid
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(LiteNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -83,18 +93,17 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(LiteNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -108,63 +117,82 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	panic("unreachable")
 }
 
-// InsertPersist is similar to insert but the receiver isn't modified.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// InsertPersist adds or updates a network prefix and its associated value in the trie
+// using Copy-On-Write (COW) semantics. Traversal begins at the specified byte depth.
+//
+// The trie utilizes path compression to conserve memory. A prefix is inserted:
+//   - Directly into a node's prefix table if the current depth matches the prefix's stride count.
+//   - As a path-compressed FringeNode if it qualifies as a fringe node.
+//   - As a path-compressed LeafNode if it falls between byte boundaries.
+//
+// Unlike Insert, InsertPersist ensures structural integrity of the existing tree
+// by cloning internal nodes along the descent path (Copy-On-Write) before mutation.
+//
+// When a new prefix collides with an existing compressed node (Leaf or Fringe),
+// InsertPersist resolves the collision by creating a new intermediate node,
+// pushing the existing entry down to the next level, and continuing traversal.
+//
+// Parameters:
+//   - cloneFn: The function used to clone values (V).
+//   - pfx: The network prefix to insert (must be in canonical/masked form).
+//   - val: The value to associate with the prefix.
+//   - depth: The current depth in the trie (0-based byte index).
+//
+// Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the proper trie node to insert prefix
-	// start with prefix octet at depth
+	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
+	// We descend through the trie until we either reach the final stride (depth == strideCount)
+	// or find an empty child slot where we can path-compress the remaining strides.
 	for ; depth < len(octets); depth++ {
 		octet := octets[depth]
 
-		// last masked octet: insert/override prefix/val into node
+		// The current depth matches the prefix's stride count, meaning this is the final
+		// node for this prefix. We insert it directly into this node's prefix table.
 		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
-		// reached end of trie path ...
+		// No child exists at this octet path. Instead of creating intermediate nodes
+		// for the remaining strides, we path-compress the rest of the prefix into a single child slot.
 		if !n.Children.Test(octet) {
-			// insert prefix path compressed as leaf or fringe
+			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
+			// it acts as a default route for everything below it. We store it as a FringeNode.
+			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
 			if IsFringe(depth, pfx) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
 		}
 
-		// ... or descend down the trie
+		// A child already exists at this octet path. Retrieve it to either continue
+		// our descent along the strides or resolve a structural collision with a compressed node.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf at addr
 		switch kid := kid.(type) {
 		case *LiteNode[V]:
-			// clone the traversed path
-
-			// kid points now to cloned kid
+			// Standard intermediate node: Clone the traversed path to maintain persistence (COW).
+			// We clone the child node before modifying it, then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// replace kid with clone
 			n.InsertChild(octet, kid)
-
 			n = kid
-			continue // descend down to next trie level
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix
-			// override value in slot if prefixes are equal
+			// Collision with an existing path-compressed LeafNode.
+			// If it's the exact same prefix, simply update the value.
 			if kid.Prefix == pfx {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the leaf down
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution: the paths diverge.
+			// 1. Create a new intermediate node.
+			// 2. Push the existing leaf down into this new node.
+			// 3. Replace the current child slot with the new node.
+			// 4. Descend into the new node to continue inserting 'pfx'.
 			newNode := new(LiteNode[V])
 			newNode.Insert(kid.Prefix, kid.Value, depth+1)
 
@@ -172,18 +200,17 @@ func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			n = newNode
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe
-			// override value in slot if pfx is a fringe
+			// Collision with an existing path-compressed FringeNode.
+			// If the incoming prefix is also a fringe at this depth, update the value.
 			if IsFringe(depth, pfx) {
 				kid.Value = val
-				// exists
 				return true
 			}
 
-			// create new node
-			// push the fringe down, it becomes a default route (idx=1)
-			// insert new child at current leaf position (addr)
-			// descend down, replace n with new child
+			// Collision resolution:
+			// The existing FringeNode acts as a catch-all (default route) for this sub-trie.
+			// To allow the incoming prefix to branch further, we expand the FringeNode
+			// into a full intermediate node and place its value at the default route index (1).
 			newNode := new(LiteNode[V])
 			newNode.InsertPrefix(1, kid.Value)
 
@@ -193,30 +220,31 @@ func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		default:
 			panic("logic error, wrong node type")
 		}
-
 	}
-
 	panic("unreachable")
 }
 
-// PurgeAndCompress performs bottom-up compression of the trie.
+// PurgeAndCompress performs bottom-up trie maintenance to restore path compression
+// after a deletion. It unwinds the provided stack of parent nodes, identifying
+// nodes that have become sparse (i.e., containing only a single prefix or a single
+// child node) and prunes them by promoting the underlying entries to the parent level.
 //
-// The function unwinds the provided stack of parent nodes, checking each level
-// for compression opportunities based on child and prefix count.
-// It may convert:
-//   - Nodes with a single prefix into leaf one level above.
-//   - Nodes with a single leaf or fringe into leaf one level above.
+// This ensures the trie remains memory-efficient by collapsing redundant intermediate
+// nodes back into path-compressed LeafNodes or FringeNodes whenever possible.
 //
 // Parameters:
-//   - stack: Array of parent nodes to process during unwinding
-//   - octets: The path of octets taken to reach the current position
-//   - is4: True for IPv4 processing, false for IPv6
+//   - stack: Array of parent nodes to process during bottom-up unwinding.
+//   - octets: The full path of octets leading to the current node.
+//   - is4: True for IPv4 processing, false for IPv6.
 func (n *LiteNode[V]) PurgeAndCompress(stack []*LiteNode[V], octets []uint8, is4 bool) {
-	// unwind the stack
+	// Iterate backwards through the ancestor stack to prune nodes from the bottom up.
 	for depth := len(stack) - 1; depth >= 0; depth-- {
 		parent := stack[depth]
 		octet := octets[depth]
 
+		// Check if the current node is redundant.
+		// A node is redundant if it contains exactly one entry (either a prefix or a child node).
+		// If it contains more than one entry, it is structurally significant and cannot be pruned.
 		pfxCount := n.PrefixCount()
 		childCount := n.ChildCount()
 
@@ -226,129 +254,133 @@ func (n *LiteNode[V]) PurgeAndCompress(stack []*LiteNode[V], octets []uint8, is4
 
 		switch {
 		case childCount == 1:
-			singleAddr, _ := n.Children.FirstSet() // single addr must be first bit set
+			// The node has exactly one child. We determine if it is a path node,
+			// a compressed LeafNode, or a compressed FringeNode.
+			singleAddr, _ := n.Children.FirstSet()
 			anyKid := n.MustGetChild(singleAddr)
 
 			switch kid := anyKid.(type) {
 			case *LiteNode[V]:
-				// fast exit, we are at an intermediate path node
-				// no further delete/compress upwards the stack is possible
+				// The child is an intermediate path node; the tree structure is required
+				// at this level. Compression cannot proceed further up.
 				return
 			case *LeafNode[V]:
-				// just one leaf, delete this node and reinsert the leaf above
+				// The child is a compressed LeafNode. Prune the current empty node
+				// and re-insert the leaf into the parent to elevate it.
 				parent.DeleteChild(octet)
-
-				// ... (re)insert the leaf at parents depth
 				parent.Insert(kid.Prefix, kid.Value, depth)
 			case *FringeNode[V]:
-				// just one fringe, delete this node and reinsert the fringe as leaf above
+				// The child is a compressed FringeNode. Prune the current node
+				// and re-insert the fringe as a leaf into the parent.
 				parent.DeleteChild(octet)
 
-				// rebuild the prefix with octets, depth, ip version and addr
-				// depth is the parent's depth, so add +1 here for the kid
-				// lastOctet in cidrForFringe is the only addr (singleAddr)
+				// Reconstruct the full prefix for the fringe, as path compression
+				// requires the entire CIDR path, not just the remainder.
+				// depth is the parent's depth, so we offset by 1 for the kid's position.
 				fringePfx := CidrForFringe(octets, depth+1, is4, singleAddr)
 
-				// ... (re)reinsert prefix/value at parents depth
 				parent.Insert(fringePfx, kid.Value, depth)
 			}
 
 		case pfxCount == 1:
-			// just one prefix, delete this node and reinsert the idx as leaf above
+			// The node has exactly one prefix. Prune the node and elevate the
+			// prefix to the parent level as a leaf/fringe.
 			parent.DeleteChild(octet)
 
-			// get prefix back from idx ...
-			idx, _ := n.Prefixes.FirstSet() // single idx must be first bit set
+			// Retrieve the single prefix stored in this node.
+			idx, _ := n.Prefixes.FirstSet()
 			val := n.MustGetPrefix(idx)
 
-			// ... and octet path
+			// Reconstruct the prefix from the path for re-insertion.
 			path := StridePath{}
 			copy(path[:], octets)
-
-			// depth is the parent's depth, so add +1 here for the kid
 			pfx := CidrFromPath(path, depth+1, is4, idx)
 
-			// ... (re)insert prefix/value at parents depth
 			parent.Insert(pfx, val, depth)
 		}
 
-		// climb up the stack
+		// Move up to the next parent in the stack to continue pruning.
 		n = parent
 	}
 }
 
-// Delete deletes the prefix and returns true if the prefix existed,
-// or false otherwise. The prefix must be in canonical form.
+// Delete removes the prefix from the trie rooted at n and returns true if the
+// prefix existed, false if it was not found. The prefix must be in canonical
+// (masked) form.
+//
+// The trie uses path compression, so a prefix may be stored in one of three ways:
+//   - In the current node's prefix table when the prefix length aligns exactly
+//     with the stride boundary at this depth (depth == strideCount).
+//   - As a path-compressed FringeNode in a child slot for stride-aligned prefixes
+//     (e.g. /8, /16, /24); occurs at depth == strideCount-1.
+//   - As a path-compressed LeafNode in a child slot for prefixes that fall
+//     between stride boundaries.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
-	ip := pfx.Addr()
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// record the nodes on the path to the deleted node, needed to purge
-	// and/or path compress nodes after the deletion of a prefix
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
 	stack := [MaxTreeDepth]*LiteNode[V]{}
 
-	// find the trie node
 	for depth, octet := range octets {
-		depth &= DepthMask // BCE, Delete must be fast
+		depth &= DepthMask // BCE hint; keep Delete on the fast path
 
-		// push current node on stack for path recording
-		stack[depth] = n
+		stack[depth] = n // record current node before descending
 
-		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
 			}
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
 			return true
 		}
 
+		// no child node exists at this octet; the prefix is not in the trie
 		if !n.Children.Test(octet) {
 			return false
 		}
+
+		// A child node exists at this octet path, retrieve it.
 		kid := n.MustGetChild(octet)
 
-		// kid is node or leaf or fringe at octet
 		switch kid := kid.(type) {
 		case *LiteNode[V]:
-			n = kid // descend down to next trie level
+			n = kid // descend to the next trie level
 
 		case *FringeNode[V]:
-			// if pfx is no fringe at this depth, fast exit
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
 				return false
 			}
 
-			// pfx is fringe at depth, delete fringe
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Attention: pfx must be masked to be comparable!
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
 				return false
 			}
 
-			// prefix is equal leaf, delete leaf
 			n.DeleteChild(octet)
 
-			// remove now-empty nodes and re-path-compress upwards
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
@@ -359,142 +391,148 @@ func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	panic("unreachable")
 }
 
-// DeletePersist is similar to delete but does not mutate the original trie.
-// Assumes the caller has pre-cloned the root (COW). It clones the
-// internal nodes along the descent path before mutating them.
+// DeletePersist removes the prefix from the trie rooted at n using Copy-On-Write (COW) semantics.
+// It returns true if the prefix existed, false if it was not found. The prefix must be in
+// canonical (masked) form.
+//
+// Like Delete, this method uses path compression. However, DeletePersist ensures
+// the structural integrity of the existing tree by cloning internal nodes along the
+// descent path (COW) before mutation.
+//
+// After a successful deletion, PurgeAndCompress walks the ancestor stack to prune
+// now-empty nodes and restore path compression upward.
 func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
-	ip := pfx.Addr() // the pfx must be in canonical form
+	ip := pfx.Addr() // pfx must be in canonical (masked) form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// Stack to keep track of cloned nodes along the path,
-	// needed for purge and path compression after delete.
+	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
+	// walk back up and clean up empty or re-compressible nodes after deletion.
+	// Since this is a COW operation, we store the cloned nodes here.
 	stack := [MaxTreeDepth]*LiteNode[V]{}
 
-	// Traverse the trie to locate the prefix to delete.
 	for depth, octet := range octets {
-		// Keep track of the cloned node at current depth.
-		stack[depth] = n
+		depth &= DepthMask // BCE hint; keep DeletePersist on the fast path
+		stack[depth] = n   // record current node before descending
 
+		// At the stride boundary, the prefix is stored directly in this node's
+		// prefix table.
 		if depth == strideCount {
-			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
-				// Prefix not found, nothing deleted.
 				return false
 			}
 
-			// After deletion, purge nodes and compress the path if needed.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 		}
 
-		addr := octet
-
-		// If child node doesn't exist, no prefix to delete.
-		if !n.Children.Test(addr) {
+		// no child node exists at this octet; the prefix is not in the trie
+		if !n.Children.Test(octet) {
 			return false
 		}
 
-		// Fetch child node at current address.
-		kid := n.MustGetChild(addr)
+		// A child node exists at this octet path, retrieve it to either continue
+		// our descent or perform a persistent delete on a compressed node.
+		kid := n.MustGetChild(octet)
 
 		switch kid := kid.(type) {
 		case *LiteNode[V]:
-			// Clone the internal node for copy-on-write.
+			// Standard intermediate node: Clone the traversed path to maintain
+			// persistence (COW). We clone the child node before modifying it,
+			// then replace the current child slot.
 			kid = kid.CloneFlat(cloneFn)
-
-			// Replace child with cloned node.
-			n.InsertChild(addr, kid)
-
-			// Descend to cloned child node.
+			n.InsertChild(octet, kid)
 			n = kid
 			continue
 
 		case *FringeNode[V]:
-			// Reached a path compressed fringe.
+			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
+			// If pfx does not qualify as a fringe at this depth, it cannot be here.
 			if !IsFringe(depth, pfx) {
-				// Prefix to delete not found here.
 				return false
 			}
 
-			// Delete the fringe node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		case *LeafNode[V]:
-			// Reached a path compressed leaf node.
+			// A LeafNode holds exactly one path-compressed prefix.
+			// Compare using the canonical (masked) form for an exact match.
 			if kid.Prefix != pfx {
-				// Leaf prefix does not match; nothing to delete.
 				return false
 			}
 
-			// Delete leaf node.
-			n.DeleteChild(addr)
+			n.DeleteChild(octet)
 
-			// Purge and compress affected path.
+			// prune now-empty nodes and re-compress the path upwards
 			n.PurgeAndCompress(stack[:depth], octets, is4)
-
 			return true
 
 		default:
-			// Unexpected node type indicates a logic error.
 			panic("logic error, wrong node type")
 		}
 	}
 
-	// Should never happen: traversal always returns or panics inside loop.
 	panic("unreachable")
 }
 
 // Get retrieves the value associated with the given network prefix.
-// Returns the stored value and true if the prefix exists in this node,
-// zero value and false if the prefix is not found.
+// Traversal descends through the trie using the prefix's octets.
+//
+// The lookup handles path compression transparently:
+//   - If the path matches an internal node at the target stride, the value is retrieved
+//     from the node's prefix table.
+//   - If the path leads to a compressed LeafNode or FringeNode, the function verifies
+//     the prefix match before returning the value.
 //
 // Parameters:
-//   - pfx: The network prefix to look up (must be in canonical form)
+//   - pfx: The network prefix to look up (must be in canonical form).
 //
 // Returns:
-//   - val: The value associated with the prefix (zero value if not found)
-//   - exists: True if the prefix was found, false otherwise
+//   - val: The value associated with the prefix (zero value if not found).
+//   - exists: True if the prefix was found, false otherwise.
 func (n *LiteNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
-	// invariant, prefix must be masked
-
-	// values derived from pfx
+	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
 	strideCount, lastBits := DivMod8(pfx)
 
-	// find the trie node
+	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
+		// At the target stride boundary, the prefix is expected in this node's
+		// prefix table.
 		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
+		// If no child exists at this path, the prefix is not in the trie.
 		kidAny, ok := n.GetChild(octet)
 		if !ok {
 			return val, false
 		}
 
-		// kid is node or leaf or fringe at octet
+		// Identify the node type at this path segment.
 		switch kid := kidAny.(type) {
 		case *LiteNode[V]:
-			n = kid // descend down to next trie level
+			// Standard intermediate node: descend to the next level.
+			n = kid
 
 		case *FringeNode[V]:
-			// reached a path compressed fringe, stop traversing
+			// Reached a path-compressed FringeNode.
+			// Verify if the prefix qualifies as a fringe at this depth to return a match.
 			if IsFringe(depth, pfx) {
 				return kid.Value, true
 			}
 			return val, false
 
 		case *LeafNode[V]:
-			// reached a path compressed prefix, stop traversing
+			// Reached a path-compressed LeafNode.
+			// Check if the stored prefix matches the lookup prefix exactly.
 			if kid.Prefix == pfx {
 				return kid.Value, true
 			}
@@ -512,7 +550,7 @@ func (n *LiteNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 // The callback receives the current value (if found) and existence flag, and returns
 // a new value and deletion flag.
 //
-// modify returns the size delta (-1, 0, +1).
+// Modify returns the size delta (-1, 0, +1).
 // This method handles path traversal, node creation for new paths, and automatic
 // purge/compress operations after deletions.
 //
@@ -774,8 +812,8 @@ func (n *LiteNode[V]) EqualRec(o *LiteNode[V]) bool {
 //
 // It returns immediately if n is nil or empty. For each visited internal node
 // it calls dump to write the node's representation, then iterates its child
-// addresses and recurses into children that implement nodeDumper[V] (internal
-// subnodes). The path slice and depth together represent the byte-wise path
+// addresses and recurses into children of type *LiteNode[V] (internal subnodes).
+// The path slice and depth together represent the byte-wise path
 // from the root to the current node; depth is incremented for each recursion.
 // The is4 flag controls IPv4/IPv6 formatting used by dump.
 func (n *LiteNode[V]) DumpRec(w io.Writer, path StridePath, depth int, is4 bool) {
@@ -967,7 +1005,7 @@ func (n *LiteNode[V]) DumpString(octets []uint8, depth int, is4 bool) string {
 //   - stopNode: has children but no subnodes (nodes == 0)
 //   - halfNode: contains at least one leaf or fringe and also has subnodes, but
 //     no prefixes
-//   - fullNode: has prefixes or leaves/fringes and also has subnodes
+//   - fullNode: has prefixes and also has subnodes
 //   - pathNode: has subnodes only (no prefixes, leaves, or fringes)
 //
 // The order of these checks is significant to ensure the correct classification.
@@ -1024,7 +1062,7 @@ func (n *LiteNode[V]) Stats() (s StatsT) {
 // It walks the node tree recursively and sums immediate counts (prefixes and
 // child slots) plus the number of nodes, leaves, and fringe nodes in the
 // subtree. If n is nil or empty, a zeroed stats is returned. The returned
-// stats.nodes includes the current node. The function will panic if a child
+// SubNodes count includes the current node. The function will panic if a child
 // has an unexpected concrete type.
 func (n *LiteNode[V]) StatsRec() (s StatsT) {
 	if n == nil || n.IsEmpty() {
@@ -1178,7 +1216,7 @@ func (n *LiteNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				path[depth] = addr
 				directItems = append(directItems, kid.DirectItemsRec(0, path, depth+1, is4)...)
 
-			case *LeafNode[V]: // path-compressed child, stop's recursion for this child
+			case *LeafNode[V]: // path-compressed child, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1187,7 +1225,7 @@ func (n *LiteNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 				}
 				directItems = append(directItems, item)
 
-			case *FringeNode[V]: // path-compressed fringe, stop's recursion for this child
+			case *FringeNode[V]: // path-compressed fringe, stops recursion for this child
 				item := TrieItem[V]{
 					Node: nil,
 					Is4:  is4,
@@ -1951,9 +1989,8 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
-		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
@@ -1998,7 +2035,7 @@ func (n *LiteNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 
 	// find the trie node
 	for depth, octet := range octets {
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {
@@ -2120,7 +2157,7 @@ func (n *LiteNode[V]) Overlaps(o *LiteNode[V], depth int) bool {
 // OverlapsRoutes compares the prefix sets of two nodes (n and o).
 //
 // It first checks for direct bitset intersection (identical indices),
-// then walks both prefix sets using lpmTest to detect if any
+// then walks both prefix sets using the Contains method to detect if any
 // of the n-prefixes is contained in o, or vice versa.
 func (n *LiteNode[V]) OverlapsRoutes(o *LiteNode[V]) bool {
 	// some prefixes are identical, trivial overlap

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -34,7 +34,7 @@ import (
 func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -42,7 +42,7 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -114,7 +114,7 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the proper trie node to insert prefix
 	// start with prefix octet at depth
@@ -122,7 +122,7 @@ func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		octet := octets[depth]
 
 		// last masked octet: insert/override prefix/val into node
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.InsertPrefix(art.PfxToIdx(octet, lastBits), val)
 		}
 
@@ -286,7 +286,7 @@ func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -300,9 +300,9 @@ func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// try to delete prefix in trie node
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				return false
@@ -366,7 +366,7 @@ func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 	ip := pfx.Addr() // the pfx must be in canonical form
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// Stack to keep track of cloned nodes along the path,
 	// needed for purge and path compression after delete.
@@ -377,7 +377,7 @@ func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		// Keep track of the cloned node at current depth.
 		stack[depth] = n
 
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			// Attempt to delete the prefix from the node's prefixes.
 			if exists = n.DeletePrefix(art.PfxToIdx(octet, lastBits)); !exists {
 				// Prefix not found, nothing deleted.
@@ -468,11 +468,11 @@ func (n *LiteNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.GetPrefix(art.PfxToIdx(octet, lastBits))
 		}
 
@@ -528,7 +528,7 @@ func (n *LiteNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -542,9 +542,9 @@ func (n *LiteNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 		stack[depth] = n
 
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 
 			oldVal, existed := n.GetPrefix(idx)
@@ -1877,7 +1877,7 @@ func (n *LiteNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*LiteNode[V]{}
@@ -1890,7 +1890,7 @@ func (n *LiteNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bo
 LOOP:
 	for depth, octet = range octets {
 		// stepped one past the last stride of interest; back up to last and exit
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -1952,9 +1952,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)
@@ -1994,14 +1994,14 @@ func (n *LiteNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool
 	ip := pfx.Addr()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	// find the trie node
 	for depth, octet := range octets {
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4/16),
+		// Note: For /32 and /128, depth never reaches strideCount (4/16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx := art.PfxToIdx(octet, lastBits)
 			n.EachSubnet(octets, depth, is4, idx, yield)
 			return
@@ -2264,17 +2264,17 @@ func (n *LiteNode[V]) OverlapsSameChildren(o *LiteNode[V], depth int) bool {
 func (n *LiteNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := DivMod8(pfx)
 
 	for ; depth < len(octets); depth++ {
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			break
 		}
 
 		octet := octets[depth]
 
 		// full octet path in node trie, check overlap with last prefix octet
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			return n.OverlapsIdx(art.PfxToIdx(octet, lastBits))
 		}
 

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -37,8 +37,9 @@ import (
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -58,7 +59,7 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -95,7 +96,7 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -141,8 +142,9 @@ func (n *LiteNode[V]) Insert(pfx netip.Prefix, val V, depth int) (exists bool) {
 // Returns true if an existing prefix was updated, false if a new insertion occurred.
 func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix, val V, depth int) (exists bool) {
 	ip := pfx.Addr() // the pfx must be in canonical form
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the prefix's octets. Each depth corresponds to an 8-bit stride.
 	// We descend through the trie until we either reach the final stride (depth == strideCount)
@@ -162,7 +164,7 @@ func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 			// If the prefix is perfectly aligned with the next stride boundary (e.g., /16 at depth 1),
 			// it acts as a default route for everything below it. We store it as a FringeNode.
 			// Otherwise, it has trailing bits or crosses boundaries, so we store it as a LeafNode.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return n.InsertChild(octet, NewFringeNode(val))
 			}
 			return n.InsertChild(octet, NewLeafNode(pfx, val))
@@ -202,7 +204,7 @@ func (n *LiteNode[V]) InsertPersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// Collision with an existing path-compressed FringeNode.
 			// If the incoming prefix is also a fringe at this depth, update the value.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				kid.Value = val
 				return true
 			}
@@ -320,9 +322,10 @@ func (n *LiteNode[V]) PurgeAndCompress(stack []*LiteNode[V], octets []uint8, is4
 // now-empty nodes and restore path compression upward.
 func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -360,7 +363,7 @@ func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -403,9 +406,10 @@ func (n *LiteNode[V]) Delete(pfx netip.Prefix) (exists bool) {
 // now-empty nodes and restore path compression upward.
 func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix) (exists bool) {
 	ip := pfx.Addr() // pfx must be in canonical (masked) form
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Record ancestor nodes as we descend; PurgeAndCompress uses this stack to
 	// walk back up and clean up empty or re-compressible nodes after deletion.
@@ -450,7 +454,7 @@ func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 		case *FringeNode[V]:
 			// A FringeNode holds a single stride-aligned prefix (/8, /16, ...).
 			// If pfx does not qualify as a fringe at this depth, it cannot be here.
-			if !IsFringe(depth, pfx) {
+			if !IsFringe(depth, pfxLen) {
 				return false
 			}
 
@@ -499,8 +503,9 @@ func (n *LiteNode[V]) DeletePersist(cloneFn value.CloneFunc[V], pfx netip.Prefix
 func (n *LiteNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 	// The prefix must be provided in canonical (masked) form for correct trie traversal.
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// Traverse the trie octet by octet based on the prefix path.
 	for depth, octet := range octets {
@@ -525,7 +530,7 @@ func (n *LiteNode[V]) Get(pfx netip.Prefix) (val V, exists bool) {
 		case *FringeNode[V]:
 			// Reached a path-compressed FringeNode.
 			// Verify if the prefix qualifies as a fringe at this depth to return a match.
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				return kid.Value, true
 			}
 			return val, false
@@ -564,9 +569,10 @@ func (n *LiteNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 	var zero V
 
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// record the nodes on the path to the deleted node, needed to purge
 	// and/or path compress nodes after the deletion of a prefix
@@ -623,7 +629,7 @@ func (n *LiteNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 			}
 
 			// insert
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				n.InsertChild(octet, NewFringeNode(newVal))
 			} else {
 				n.InsertChild(octet, NewLeafNode(pfx, newVal))
@@ -682,7 +688,7 @@ func (n *LiteNode[V]) Modify(pfx netip.Prefix, cb func(val V, found bool) (_ V, 
 
 		case *FringeNode[V]:
 			// update existing value if prefix is fringe
-			if IsFringe(depth, pfx) {
+			if IsFringe(depth, pfxLen) {
 				newVal, del := cb(kid.Value, true)
 				if !del {
 					kid.Value = newVal
@@ -1913,9 +1919,10 @@ func (n *LiteNode[V]) EachSubnet(octets []byte, depth int, is4 bool, pfxIdx uint
 // the iteration early.
 func (n *LiteNode[V]) Supernets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// stack of the traversed nodes for reverse ordering of supernets
 	stack := [MaxTreeDepth]*LiteNode[V]{}
@@ -2029,9 +2036,10 @@ LOOP:
 func (n *LiteNode[V]) Subnets(pfx netip.Prefix, yield func(netip.Prefix, V) bool) {
 	// values derived from pfx
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	// find the trie node
 	for depth, octet := range octets {
@@ -2300,8 +2308,9 @@ func (n *LiteNode[V]) OverlapsSameChildren(o *LiteNode[V], depth int) bool {
 // trie traversal across varying prefix lengths and compression levels.
 func (n *LiteNode[V]) OverlapsPrefixAtDepth(pfx netip.Prefix, depth int) bool {
 	ip := pfx.Addr()
+	pfxLen := pfx.Bits()
 	octets := ip.AsSlice()
-	strideCount, lastBits := DivMod8(pfx)
+	strideCount, lastBits := DivMod8(pfxLen)
 
 	for ; depth < len(octets); depth++ {
 		if depth > strideCount {

--- a/internal/nodes/litetestsgenerated_test.go
+++ b/internal/nodes/litetestsgenerated_test.go
@@ -1225,7 +1225,7 @@ func TestSupernetsExtra_LiteNode(t *testing.T) {
 		t.Errorf("expected yieldCount 1 on backtracking early exit, got %d", yieldCount)
 	}
 
-	// 4. Trigger depth > lastOctetPlusOne
+	// 4. Trigger depth > strideCount
 	yielded = []netip.Prefix{}
 	n.Supernets(mpp("10.40.0.0/16"), func(pfx netip.Prefix, val int) bool {
 		yielded = append(yielded, pfx)

--- a/internal/nodes/nodebasics.go
+++ b/internal/nodes/nodebasics.go
@@ -187,8 +187,8 @@ func NewFringeNode[V any](val V) *FringeNode[V] {
 //   - A prefix qualifies as a fringe if:
 //     depth == strideCount - 1 && remainder == 0
 //     (i.e., aligned on stride boundary, /8, /16, ... /128 bits)
-func IsFringe(depth int, pfx netip.Prefix) bool {
-	strideCount, lastBits := DivMod8(pfx)
+func IsFringe(depth int, pfxLen int) bool {
+	strideCount, lastBits := DivMod8(pfxLen)
 	return depth == strideCount-1 && lastBits == 0
 }
 
@@ -282,7 +282,7 @@ func CidrForFringe(octets []byte, depth int, is4 bool, fringeByte uint8) netip.P
 }
 
 // DivMod8 returns the count of full 8‑bit strides (bits/8)
-// and the remaining bits in the final stride (bits%8) for pfx.
+// and the remaining bits in the final stride (bits%8) for pfxLen.
 //
 // ATTENTION: Split the IP prefixes at 8-bit borders, count from 0.
 //
@@ -311,18 +311,18 @@ func CidrForFringe(octets []byte, depth int, is4 bool, fringeByte uint8) netip.P
 // We are not splitting at /8, /16, ..., because this would mean that the
 // first node would have 512 prefixes, 9 bits from [0-8]. All remaining nodes
 // would then only have 8 bits from [9-16], [17-24], [25..32], ...
-// but the algorithm would then require a variable length bitset.
+// but the algorithm would then require a variable length bitset
+// or imply a double-sized bitset.
 //
 // If you can commit to a fixed size of [4]uint64, then the algorithm is
 // much faster due to modern CPUs.
 //
 // Perhaps a future Go version that supports SIMD instructions for the [4]uint64 vectors
 // will make the algorithm even faster on suitable hardware.
-func DivMod8(pfx netip.Prefix) (strideCount int, remainder uint8) {
+func DivMod8(pfxLen int) (strideCount int, remainder uint8) {
 	// strideCount:  range from 0..4 or 0..16
 	// remainder:    range from 0..7
-	bits := pfx.Bits()
-	return bits >> 3, uint8(bits & 7)
+	return pfxLen >> 3, uint8(pfxLen & 7)
 }
 
 // CloneLeaf creates and returns a copy of the leafNode receiver.

--- a/internal/nodes/nodebasics.go
+++ b/internal/nodes/nodebasics.go
@@ -161,36 +161,35 @@ func NewFringeNode[V any](val V) *FringeNode[V] {
 
 // IsFringe determines whether a prefix qualifies as a "fringe node" -
 // that is, a special kind of path-compressed leaf inserted at the final
-// possible trie level (depth == lastOctet).
+// possible trie level (depth == strideCount - 1).
 //
 // Both "leaves" and "fringes" are path-compressed terminal entries;
 // the distinction lies in their position within the trie:
 //
 //   - A leaf is inserted at any intermediate level if no further stride
-//     boundary matches (depth < lastOctet).
+//     boundary matches (depth < strideCount - 1).
 //
 //   - A fringe is inserted at the last possible stride level
-//     (depth == lastOctet) before a prefix would otherwise land
-//     as a direct prefix (depth == lastOctet+1).
+//     (depth == strideCount - 1) before a prefix would otherwise land
+//     as a direct prefix in the next level (depth == strideCount).
 //
 // Special property:
 //   - A fringe acts as a default route for all downstream bit patterns
 //     extending beyond its prefix.
 //
-// Examples:
+// Examples for a stride-aligned prefix like 192.168.1.0/24 (strideCount = 3, remainder = 0):
 //
-//	e.g., prefix is addr/8, or addr/16, or ... addr/128
-//	depth <  lastOctet :  a leaf, path-compressed
-//	depth == lastOctet :  a fringe, path-compressed
-//	depth == lastOctet+1: a prefix with octet/pfx == 0/0 => idx == 1, a strides default route
+//	depth <  2  (depth < strideCount - 1)  : A leaf, path-compressed.
+//	depth == 2  (depth == strideCount - 1) : A fringe, path-compressed.
+//	depth == 3  (depth == strideCount)     : A direct prefix with octet == 0 => idx == 1 (default route).
 //
 // Logic:
 //   - A prefix qualifies as a fringe if:
-//     depth == lastOctet && lastBits == 0
+//     depth == strideCount - 1 && remainder == 0
 //     (i.e., aligned on stride boundary, /8, /16, ... /128 bits)
 func IsFringe(depth int, pfx netip.Prefix) bool {
-	lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
-	return depth == lastOctetPlusOne-1 && lastBits == 0
+	strideCount, lastBits := DivMod8(pfx)
+	return depth == strideCount-1 && lastBits == 0
 }
 
 // CmpIndexRank, sort indexes in prefix sort order.
@@ -247,21 +246,21 @@ func CidrFromPath(path StridePath, depth int, is4 bool, idx uint8) netip.Prefix 
 
 // CidrForFringe reconstructs a CIDR prefix for a fringe node from the traversal path.
 // Since fringe nodes don't store their prefix explicitly, it's derived entirely
-// from the node's position in the trie.
+// from the node's position in the trie and its final byte value.
 //
 // Parameters:
-//   - octets: The path of octets leading to the fringe
-//   - depth: Current depth in the trie
-//   - is4: True for IPv4 processing, false for IPv6
-//   - lastOctet: The final octet where the fringe is located
+//   - octets:     The path of previous bytes leading up to the fringe.
+//   - depth:      Current depth in the trie (which equals strideCount - 1).
+//   - is4:        True for IPv4 processing, false for IPv6.
+//   - fringeByte: The actual 8-bit value (0-255) of the prefix at this final stride.
 //
 // Returns the reconstructed netip.Prefix for the fringe.
-func CidrForFringe(octets []byte, depth int, is4 bool, lastOctet uint8) netip.Prefix {
+func CidrForFringe(octets []byte, depth int, is4 bool, fringeByte uint8) netip.Prefix {
 	depth &= DepthMask // BCE
 
 	var path StridePath
 	copy(path[:], octets)
-	path[depth] = lastOctet
+	path[depth] = fringeByte
 
 	// canonicalize, fringe bit boundaries are always a multiple of a byte
 	clear(path[depth+1:])
@@ -274,7 +273,7 @@ func CidrForFringe(octets []byte, depth int, is4 bool, lastOctet uint8) netip.Pr
 		ip = netip.AddrFrom16(path)
 	}
 
-	// it's a fringe, bits are always /8, /16, /24, ...
+	// it's a fringe, bits are always aligned on stride boundaries (/8, /16, /24, ...)
 	bits := (depth + 1) << 3
 
 	// PrefixFrom does not allocate and does not mask off the host bits of ip.
@@ -282,8 +281,8 @@ func CidrForFringe(octets []byte, depth int, is4 bool, lastOctet uint8) netip.Pr
 	return netip.PrefixFrom(ip, bits)
 }
 
-// LastOctetPlusOneAndLastBits returns the count of full 8‑bit strides (bits/8)
-// and the leftover bits in the final stride (bits%8) for pfx.
+// DivMod8 returns the count of full 8‑bit strides (bits/8)
+// and the remaining bits in the final stride (bits%8) for pfx.
 //
 // ATTENTION: Split the IP prefixes at 8-bit borders, count from 0.
 //
@@ -292,18 +291,18 @@ func CidrForFringe(octets []byte, depth int, is4 bool, lastOctet uint8) netip.Pr
 //	BitPos: [0-7],[8-15],[16-23],[24-31],[32]
 //	BitPos: [0-7],[8-15],[16-23],[24-31],[32-39],[40-47],[48-55],[56-63],...,[120-127],[128]
 //
-//	0.0.0.0/0      => lastOctetPlusOne:  0, lastBits: 0 (default route)
-//	0.0.0.0/7      => lastOctetPlusOne:  0, lastBits: 7
-//	0.0.0.0/8      => lastOctetPlusOne:  1, lastBits: 0 (fringe candidate)
-//	10.0.0.0/8     => lastOctetPlusOne:  1, lastBits: 0 (fringe candidate)
-//	10.0.0.0/22    => lastOctetPlusOne:  2, lastBits: 6
-//	10.0.0.0/29    => lastOctetPlusOne:  3, lastBits: 5
-//	10.0.0.0/32    => lastOctetPlusOne:  4, lastBits: 0 (fringe candidate)
+//	0.0.0.0/0      => strideCount:  0, remainder: 0 (default route)
+//	0.0.0.0/7      => strideCount:  0, remainder: 7
+//	0.0.0.0/8      => strideCount:  1, remainder: 0 (fringe candidate)
+//	10.0.0.0/8     => strideCount:  1, remainder: 0 (fringe candidate)
+//	10.0.0.0/22    => strideCount:  2, remainder: 6
+//	10.0.0.0/29    => strideCount:  3, remainder: 5
+//	10.0.0.0/32    => strideCount:  4, remainder: 0 (fringe candidate)
 //
-//	::/0           => lastOctetPlusOne:  0, lastBits: 0 (default route)
-//	::1/128        => lastOctetPlusOne: 16, lastBits: 0 (fringe candidate)
-//	2001:db8::/42  => lastOctetPlusOne:  5, lastBits: 2
-//	2001:db8::/56  => lastOctetPlusOne:  7, lastBits: 0 (fringe candidate)
+//	::/0           => strideCount:  0, remainder: 0 (default route)
+//	::1/128        => strideCount: 16, remainder: 0 (fringe candidate)
+//	2001:db8::/42  => strideCount:  5, remainder: 2
+//	2001:db8::/56  => strideCount:  7, remainder: 0 (fringe candidate)
 //
 //	/32 and /128 prefixes are special, they never form a new node,
 //	At the end of the trie (IPv4: depth 4, IPv6: depth 16) they are always
@@ -319,9 +318,9 @@ func CidrForFringe(octets []byte, depth int, is4 bool, lastOctet uint8) netip.Pr
 //
 // Perhaps a future Go version that supports SIMD instructions for the [4]uint64 vectors
 // will make the algorithm even faster on suitable hardware.
-func LastOctetPlusOneAndLastBits(pfx netip.Prefix) (lastOctetPlusOne int, lastBits uint8) {
-	// lastOctetPlusOne:  range from 0..4 or 0..16 !ATTENTION: not 0..3 or 0..15
-	// lastBits:          range from 0..7
+func DivMod8(pfx netip.Prefix) (strideCount int, remainder uint8) {
+	// strideCount:  range from 0..4 or 0..16
+	// remainder:    range from 0..7
 	bits := pfx.Bits()
 	return bits >> 3, uint8(bits & 7)
 }

--- a/internal/nodes/nodebasics_test.go
+++ b/internal/nodes/nodebasics_test.go
@@ -322,7 +322,7 @@ func TestCidrForFringe(t *testing.T) {
 			expected:   "172.16.50.0/24", // path[2] = fringeByte = 50
 		},
 
-		// IPv6 test cases - KORRIGIERT
+		// IPv6 test cases
 		{
 			name:       "IPv6 fringe /8 at depth 0",
 			octets:     []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},

--- a/internal/nodes/nodebasics_test.go
+++ b/internal/nodes/nodebasics_test.go
@@ -54,7 +54,7 @@ var mpp = func(s string) netip.Prefix {
 	panic(fmt.Sprintf("%s is not canonicalized as %s", s, pfx.Masked()))
 }
 
-func TestLastOctetPlusOneAndLastBits(t *testing.T) {
+func TestStrideCount(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -111,13 +111,13 @@ func TestLastOctetPlusOneAndLastBits(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		lastOctetPlusOne, gotBits := LastOctetPlusOneAndLastBits(tc.pfx)
-		if lastOctetPlusOne != tc.wantDepth {
-			t.Errorf("LastOctetPlusOneAndLastBits(%d), lastOctetPlusOne got: %d, want: %d",
-				tc.pfx.Bits(), lastOctetPlusOne, tc.wantDepth)
+		strideCount, gotBits := DivMod8(tc.pfx)
+		if strideCount != tc.wantDepth {
+			t.Errorf("StrideCount(%d), strideCount got: %d, want: %d",
+				tc.pfx.Bits(), strideCount, tc.wantDepth)
 		}
 		if gotBits != tc.wantBits {
-			t.Errorf("LastOctetPlusOneAndLastBits(%d), lastBits got: %d, want: %d",
+			t.Errorf("StrideCount(%d), lastBits got: %d, want: %d",
 				tc.pfx.Bits(), gotBits, tc.wantBits)
 		}
 	}
@@ -289,79 +289,79 @@ func TestCidrForFringe(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		octets    []byte
-		depth     int
-		is4       bool
-		lastOctet uint8
-		expected  string
+		name       string
+		octets     []byte
+		depth      int
+		is4        bool
+		fringeByte uint8
+		expected   string
 	}{
 		// IPv4 test cases
 		{
-			name:      "IPv4 fringe /8 at depth 0",
-			octets:    []byte{10, 0, 0, 0},
-			depth:     0,
-			is4:       true,
-			lastOctet: 0,
-			expected:  "0.0.0.0/8", // path[0] = lastOctet = 0
+			name:       "IPv4 fringe /8 at depth 0",
+			octets:     []byte{10, 0, 0, 0},
+			depth:      0,
+			is4:        true,
+			fringeByte: 0,
+			expected:   "0.0.0.0/8", // path[0] = fringeByte = 0
 		},
 		{
-			name:      "IPv4 fringe /16 at depth 1",
-			octets:    []byte{192, 168, 0, 0},
-			depth:     1,
-			is4:       true,
-			lastOctet: 0,
-			expected:  "192.0.0.0/16", // path[1] = lastOctet = 0
+			name:       "IPv4 fringe /16 at depth 1",
+			octets:     []byte{192, 168, 0, 0},
+			depth:      1,
+			is4:        true,
+			fringeByte: 0,
+			expected:   "192.0.0.0/16", // path[1] = fringeByte = 0
 		},
 		{
-			name:      "IPv4 fringe with non-zero lastOctet",
-			octets:    []byte{172, 16, 0, 0},
-			depth:     2,
-			is4:       true,
-			lastOctet: 50,
-			expected:  "172.16.50.0/24", // path[2] = lastOctet = 50
+			name:       "IPv4 fringe with non-zero fringeByte",
+			octets:     []byte{172, 16, 0, 0},
+			depth:      2,
+			is4:        true,
+			fringeByte: 50,
+			expected:   "172.16.50.0/24", // path[2] = fringeByte = 50
 		},
 
 		// IPv6 test cases - KORRIGIERT
 		{
-			name:      "IPv6 fringe /8 at depth 0",
-			octets:    []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-			depth:     0,
-			is4:       false,
-			lastOctet: 0,
-			expected:  "::/8", // path[0] = lastOctet = 0
+			name:       "IPv6 fringe /8 at depth 0",
+			octets:     []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			depth:      0,
+			is4:        false,
+			fringeByte: 0,
+			expected:   "::/8", // path[0] = fringeByte = 0
 		},
 		{
-			name:      "IPv6 fringe /16 at depth 1",
-			octets:    []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-			depth:     1,
-			is4:       false,
-			lastOctet: 0,
-			expected:  "2000::/16", // path[1] = lastOctet = 0
+			name:       "IPv6 fringe /16 at depth 1",
+			octets:     []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			depth:      1,
+			is4:        false,
+			fringeByte: 0,
+			expected:   "2000::/16", // path[1] = fringeByte = 0
 		},
 		{
-			name:      "IPv6 fringe /64 at depth 7",
-			octets:    []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-			depth:     7,
-			is4:       false,
-			lastOctet: 0,
-			expected:  "2001:db8::/64", // path[7] = lastOctet = 0 (overwrites the 0x01)
+			name:       "IPv6 fringe /64 at depth 7",
+			octets:     []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			depth:      7,
+			is4:        false,
+			fringeByte: 0,
+			expected:   "2001:db8::/64", // path[7] = fringeByte = 0 (overwrites the 0x01)
 		},
 		{
-			name:      "IPv6 fringe /128 at depth 15 (host route)",
-			octets:    []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
-			depth:     15,
-			is4:       false,
-			lastOctet: 0,
-			expected:  "2001:db8:0:1::/128", // path[15] = lastOctet = 0 (overwrites the 0x01)
+			name:       "IPv6 fringe /128 at depth 15 (host route)",
+			octets:     []byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			depth:      15,
+			is4:        false,
+			fringeByte: 0,
+			expected:   "2001:db8:0:1::/128", // path[15] = fringeByte = 0 (overwrites the 0x01)
 		},
 		{
-			name:      "IPv6 fringe with non-zero lastOctet",
-			octets:    []byte{0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-			depth:     7,
-			is4:       false,
-			lastOctet: 0xff,
-			expected:  "fe80:0:0:ff::/64", // path[7] = lastOctet = 0xff
+			name:       "IPv6 fringe with non-zero fringeByte",
+			octets:     []byte{0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			depth:      7,
+			is4:        false,
+			fringeByte: 0xff,
+			expected:   "fe80:0:0:ff::/64", // path[7] = fringeByte = 0xff
 		},
 	}
 
@@ -369,7 +369,7 @@ func TestCidrForFringe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := CidrForFringe(tt.octets, tt.depth, tt.is4, tt.lastOctet)
+			result := CidrForFringe(tt.octets, tt.depth, tt.is4, tt.fringeByte)
 
 			if result.String() != tt.expected {
 				t.Errorf("Test %s: cidrForFringe() = %v, want %v", tt.name, result, tt.expected)
@@ -421,9 +421,9 @@ func TestIsFringe(t *testing.T) {
 			result := IsFringe(tt.depth, pfx)
 
 			if result != tt.expected {
-				lastOctetPlusOne, lastBits := LastOctetPlusOneAndLastBits(pfx)
-				t.Errorf("Test %s: isFringe(%d, %v) = %v, want %v (lastOctetPlusOne=%d, lastBits=%d)",
-					tt.name, tt.depth, pfx, result, tt.expected, lastOctetPlusOne, lastBits)
+				strideCount, lastBits := DivMod8(pfx)
+				t.Errorf("Test %s: isFringe(%d, %v) = %v, want %v (strideCount=%d, lastBits=%d)",
+					tt.name, tt.depth, pfx, result, tt.expected, strideCount, lastBits)
 			}
 		})
 	}
@@ -555,7 +555,7 @@ func TestCidrForFringeEdgeCases(t *testing.T) {
 		octets := []byte{10, 20, 30, 40}
 		// depth 32 should be masked to 0 (32 & 15 = 0)
 		result := CidrForFringe(octets, 32, true, 50)
-		expected := "50.0.0.0/8" // depth masked to 0, so lastOctet goes to path[0]
+		expected := "50.0.0.0/8" // depth masked to 0, so fringeByte goes to path[0]
 		if result.String() != expected {
 			t.Errorf("Expected %s with masked depth, got %s", expected, result.String())
 		}
@@ -566,7 +566,7 @@ func TestCidrForFringeEdgeCases(t *testing.T) {
 		// Test that bytes after depth+1 are cleared
 		octets := []byte{0xac, 0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e}
 		result := CidrForFringe(octets, 2, false, 0x63) // IPv6 depth 2
-		// lastOctet 0x63 goes to path[2], bytes after are cleared
+		// fringeByte 0x63 goes to path[2], bytes after are cleared
 		expected := "ac10:6300::/24" // (2+1)*8 = 24 bits
 		if result.String() != expected {
 			t.Errorf("Expected canonicalized result %s, got %s", expected, result.String())

--- a/internal/nodes/nodebasics_test.go
+++ b/internal/nodes/nodebasics_test.go
@@ -111,7 +111,7 @@ func TestStrideCount(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		strideCount, gotBits := DivMod8(tc.pfx)
+		strideCount, gotBits := DivMod8(tc.pfx.Bits())
 		if strideCount != tc.wantDepth {
 			t.Errorf("StrideCount(%d), strideCount got: %d, want: %d",
 				tc.pfx.Bits(), strideCount, tc.wantDepth)
@@ -418,10 +418,10 @@ func TestIsFringe(t *testing.T) {
 			t.Parallel()
 
 			pfx := netip.MustParsePrefix(tt.prefix)
-			result := IsFringe(tt.depth, pfx)
+			result := IsFringe(tt.depth, pfx.Bits())
 
 			if result != tt.expected {
-				strideCount, lastBits := DivMod8(pfx)
+				strideCount, lastBits := DivMod8(pfx.Bits())
 				t.Errorf("Test %s: isFringe(%d, %v) = %v, want %v (strideCount=%d, lastBits=%d)",
 					tt.name, tt.depth, pfx, result, tt.expected, strideCount, lastBits)
 			}
@@ -675,7 +675,7 @@ func TestIntegration(t *testing.T) {
 			}
 
 			fringe := CidrForFringe(octets, tc.depth, tc.is4, 0)
-			if !IsFringe(tc.depth, fringe) {
+			if !IsFringe(tc.depth, fringe.Bits()) {
 				t.Errorf("Prefix created by cidrForFringe at depth %d (is4=%t) should be detected as fringe: %v",
 					tc.depth, tc.is4, fringe)
 			}

--- a/lite.go
+++ b/lite.go
@@ -570,7 +570,7 @@ func (l *liteTable[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx n
 	bits := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	lastOctetPlusOne, lastBits := nodes.LastOctetPlusOneAndLastBits(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfx)
 
 	n := l.rootNodeByVersion(is4)
 
@@ -586,7 +586,7 @@ LOOP:
 		depth &= nodes.DepthMask // BCE
 
 		// stepped one past the last stride of interest; back up to last and break
-		if depth > lastOctetPlusOne {
+		if depth > strideCount {
 			depth--
 			break
 		}
@@ -648,9 +648,9 @@ LOOP:
 		var idx uint8
 		octet = octets[depth]
 		// Last “octet” from prefix, update/insert prefix into node.
-		// Note: For /32 and /128, depth never reaches lastOctetPlusOne (4 or 16),
+		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
 		// so those are handled below via the fringe/leaf path.
-		if depth == lastOctetPlusOne {
+		if depth == strideCount {
 			idx = art.PfxToIdx(octet, lastBits)
 		} else {
 			idx = art.OctetToIdx(octet)

--- a/lite.go
+++ b/lite.go
@@ -567,10 +567,10 @@ func (l *liteTable[V]) lookupPrefixLPM(pfx netip.Prefix, withLPM bool) (lpmPfx n
 	pfx = pfx.Masked()
 
 	ip := pfx.Addr()
-	bits := pfx.Bits()
+	pfxLen := pfx.Bits()
 	is4 := ip.Is4()
 	octets := ip.AsSlice()
-	strideCount, lastBits := nodes.DivMod8(pfx)
+	strideCount, lastBits := nodes.DivMod8(pfxLen)
 
 	n := l.rootNodeByVersion(is4)
 
@@ -607,7 +607,7 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > bits || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
 				break LOOP
 			}
 			return kid.Prefix, true
@@ -616,7 +616,7 @@ LOOP:
 			// the bits of the fringe are defined by the depth
 			// maybe the LPM isn't needed, saves some cycles
 			fringeBits := (depth + 1) << 3
-			if fringeBits > bits {
+			if fringeBits > pfxLen {
 				break LOOP
 			}
 

--- a/lite.go
+++ b/lite.go
@@ -647,7 +647,7 @@ LOOP:
 		// all others are just host routes
 		var idx uint8
 		octet = octets[depth]
-		// Last “octet” from prefix, update/insert prefix into node.
+		// Last “octet” from prefix
 		// Note: For /32 and /128, depth never reaches strideCount (4 or 16),
 		// so those are handled below via the fringe/leaf path.
 		if depth == strideCount {


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved longest-prefix-match and prefix-range operations by applying consistent trie “stride boundary” handling across IPv4 and IPv6.
  - Fixed traversal/backtracking at the final boundary for insert/delete/lookup plus supernet, subnet, and overlap searches, including correct `/32` and `/128` routing.
  - Improved trie pruning/compression so updates preserve the correct structure.
- **Tests**
  - Updated test comments and expectations to match the new stride-boundary terminology.
- **Documentation**
  - Refreshed node/boundary descriptions for clearer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->