### PR TITLE
Remove CopyVal and use identity clone defaults in union methods

### DIFF
--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -1259,7 +1259,7 @@ func (n *BartNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 // Returns the number of duplicate prefixes that were overwritten during merging.
 func (n *BartNode[V]) UnionRec(cloneFn func(V) V, o *BartNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}
@@ -1292,7 +1292,7 @@ func (n *BartNode[V]) UnionRec(cloneFn func(V) V, o *BartNode[V], depth int) (du
 // UnionRecPersist is similar to unionRec but performs an immutable union of nodes.
 func (n *BartNode[V]) UnionRecPersist(cloneFn func(V) V, o *BartNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -1293,7 +1293,7 @@ func (n *_NODE_TYPE[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth i
 // Returns the number of duplicate prefixes that were overwritten during merging.
 func (n *_NODE_TYPE[V]) UnionRec(cloneFn func(V) V, o *_NODE_TYPE[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}
@@ -1326,7 +1326,7 @@ func (n *_NODE_TYPE[V]) UnionRec(cloneFn func(V) V, o *_NODE_TYPE[V], depth int)
 // UnionRecPersist is similar to unionRec but performs an immutable union of nodes.
 func (n *_NODE_TYPE[V]) UnionRecPersist(cloneFn func(V) V, o *_NODE_TYPE[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -1259,7 +1259,7 @@ func (n *FastNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 // Returns the number of duplicate prefixes that were overwritten during merging.
 func (n *FastNode[V]) UnionRec(cloneFn func(V) V, o *FastNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}
@@ -1292,7 +1292,7 @@ func (n *FastNode[V]) UnionRec(cloneFn func(V) V, o *FastNode[V], depth int) (du
 // UnionRecPersist is similar to unionRec but performs an immutable union of nodes.
 func (n *FastNode[V]) UnionRecPersist(cloneFn func(V) V, o *FastNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -1259,7 +1259,7 @@ func (n *LiteNode[V]) DirectItemsRec(parentIdx uint8, path StridePath, depth int
 // Returns the number of duplicate prefixes that were overwritten during merging.
 func (n *LiteNode[V]) UnionRec(cloneFn func(V) V, o *LiteNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}
@@ -1292,7 +1292,7 @@ func (n *LiteNode[V]) UnionRec(cloneFn func(V) V, o *LiteNode[V], depth int) (du
 // UnionRecPersist is similar to unionRec but performs an immutable union of nodes.
 func (n *LiteNode[V]) UnionRecPersist(cloneFn func(V) V, o *LiteNode[V], depth int) (duplicates int) {
 	if cloneFn == nil {
-		cloneFn = value.CopyVal
+		cloneFn = func(v V) V { return v }
 	}
 
 	buf := [256]uint8{}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -9,22 +9,22 @@
 // # Zero-Sized Type (ZST) Detection
 //
 // IsZST[V] detects whether a type parameter V is a zero-sized type (such as
-// struct{} or [0]byte). Zero-sized types carry no information in their
+// `struct{}` or `[0]byte`). Zero-sized types carry no information in their
 // values. Omitting them from dumps and prints reduces line noise and
 // improves readability.
 //
 // # Value Equality
 //
-// The Equaler[V] interface and Equal function enable custom equality logic
-// for payload values. When V implements Equaler[V], the Equal function uses
-// that implementation, avoiding the potentially expensive reflect.DeepEqual.
+// The [Equal] function enables custom equality logic for payload values.
+// When V implements an `Equal(V) bool` method, [Equal] uses that implementation,
+// avoiding the potentially expensive [reflect.DeepEqual] fallback.
 //
 // # Value Cloning
 //
-// The Cloner[V] interface and associated functions (CloneFnFactory, CloneVal,
-// CopyVal) support deep copying of payload values for persistent operations.
-// When V implements Cloner[V], bart methods like InsertPersist, DeletePersist,
-// and UnionPersist use the Clone method to create independent copies.
+// The [CloneFnFactory] supports copying of payload values for persistent
+// operations. When V implements a `Clone() V` method,
+// bart methods like InsertPersist, DeletePersist, and UnionPersist use the
+// generated clone function to create independent copies.
 //
 // This is an internal package used by the bart data structure implementation.
 package value
@@ -35,7 +35,7 @@ import (
 
 // IsZST reports whether type V is a zero-sized type (ZST).
 //
-// Zero-sized types such as struct{}, [0]byte, or structs/arrays with no fields
+// Zero-sized types such as `struct{}`, `[0]byte`, or structs/arrays with no fields
 // occupy no memory. This function uses reflection to determine the size of the
 // type safely without relying on the unsafe package.
 func IsZST[V any]() bool {
@@ -44,10 +44,10 @@ func IsZST[V any]() bool {
 
 // Equal compares two values of type V for equality.
 //
-// If V implements an Equal(V) bool method, its custom equality logic is used.
+// If V implements an `Equal(V) bool` method, its custom equality logic is used.
 // Otherwise, it falls back to [reflect.DeepEqual].
 //
-// Note: If V implements Equal(V) bool with a pointer receiver, the Equal
+// Note: If V implements `Equal(V) bool` with a pointer receiver, the `Equal`
 // method should handle nil receivers gracefully.
 func Equal[V any](v1, v2 V) bool {
 	if eq, ok := any(v1).(interface{ Equal(V) bool }); ok {
@@ -58,11 +58,11 @@ func Equal[V any](v1, v2 V) bool {
 }
 
 // CloneFnFactory returns a function that takes a value of type V and returns
-// a copy by calling its Clone method.
+// a copy by calling its `Clone` method.
 //
-// If V does not implement a Clone() V method, it returns nil.
+// If V does not implement a `Clone() V` method, it returns nil.
 //
-// Note: If V implements Clone() V with a pointer receiver, the Clone
+// Note: If V implements `Clone() V` with a pointer receiver, the `Clone`
 // method should handle nil receivers gracefully.
 func CloneFnFactory[V any]() func(V) V {
 	var zero V

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -79,8 +79,3 @@ func CloneFnFactory[V any]() func(V) V {
 
 	return nil
 }
-
-// CopyVal just copies the value of any type V.
-func CopyVal[V any](val V) V {
-	return val
-}

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -1,7 +1,6 @@
 package value
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -337,93 +336,6 @@ func TestCloneFnFactory(t *testing.T) {
 				fnStruct := CloneFnFactory[NonCloner]()
 				if fnStruct != nil {
 					t.Errorf("expected nil function, got %T", fnStruct)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, tt.run)
-	}
-}
-
-// ============================================================================
-// Table-Driven Tests for CopyVal
-// ============================================================================
-
-func TestCopyVal(t *testing.T) {
-	type CustomStruct struct {
-		ID   int
-		Name string
-	}
-
-	tests := []struct {
-		name string
-		run  func(t *testing.T)
-	}{
-		{
-			name: "copies primitive int value",
-			run: func(t *testing.T) {
-				orig := 42
-				got := CopyVal(orig)
-
-				if got != orig {
-					t.Errorf("expected %d, got %d", orig, got)
-				}
-			},
-		},
-		{
-			name: "copies string value",
-			run: func(t *testing.T) {
-				orig := "hello go"
-				got := CopyVal(orig)
-
-				if got != orig {
-					t.Errorf("expected %q, got %q", orig, got)
-				}
-			},
-		},
-		{
-			name: "copies struct by value",
-			run: func(t *testing.T) {
-				orig := CustomStruct{ID: 1, Name: "Test"}
-				got := CopyVal(orig)
-
-				if got != orig {
-					t.Errorf("expected %+v, got %+v", orig, got)
-				}
-			},
-		},
-		{
-			name: "copies pointer value (returns exact same address)",
-			run: func(t *testing.T) {
-				orig := &CustomStruct{ID: 1, Name: "Test"}
-				got := CopyVal(orig)
-
-				if got != orig {
-					t.Errorf("expected pointer address %p, got %p", orig, got)
-				}
-			},
-		},
-		{
-			name: "copies slice value (shallow copy of slice header)",
-			run: func(t *testing.T) {
-				orig := []int{1, 2, 3}
-				got := CopyVal(orig)
-
-				if !reflect.DeepEqual(got, orig) {
-					t.Errorf("expected slice %v, got %v", orig, got)
-				}
-			},
-		},
-		{
-			name: "handles nil pointer gracefully",
-			run: func(t *testing.T) {
-				var orig *CustomStruct = nil
-				got := CopyVal(orig)
-
-				if got != nil {
-					t.Errorf("expected nil, got %v", got)
 				}
 			},
 		},


### PR DESCRIPTION
@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated record-union operations to preserve values by default when no custom cloning behavior is provided.
  * Applied consistent behavior across supported node types and persistent union operations.

* **Documentation**
  * Clarified value equality, cloning, zero-size type detection, and fallback behavior.

* **Refactor**
  * Removed the obsolete value-copying helper and its associated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->