### PR TITLE
refactor(value), avoid reflect package

### DIFF
--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -839,8 +839,8 @@ func (n *BartNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 	bits := depth * strideLen
 	indent := strings.Repeat(".", depth)
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// node type with depth and octet path and bits.
 	fmt.Fprintf(w, "\n%s[%s] depth:  %d path: [%s] / %d\n",
@@ -1116,8 +1116,8 @@ func (n *BartNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		return CmpPrefix(a.Cidr, b.Cidr)
 	})
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// for all direct item under this node ...
 	for i, item := range directItems {

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -873,8 +873,8 @@ func (n *_NODE_TYPE[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) 
 	bits := depth * strideLen
 	indent := strings.Repeat(".", depth)
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// node type with depth and octet path and bits.
 	fmt.Fprintf(w, "\n%s[%s] depth:  %d path: [%s] / %d\n",
@@ -1150,8 +1150,8 @@ func (n *_NODE_TYPE[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) e
 		return CmpPrefix(a.Cidr, b.Cidr)
 	})
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// for all direct item under this node ...
 	for i, item := range directItems {

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -839,8 +839,8 @@ func (n *FastNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 	bits := depth * strideLen
 	indent := strings.Repeat(".", depth)
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// node type with depth and octet path and bits.
 	fmt.Fprintf(w, "\n%s[%s] depth:  %d path: [%s] / %d\n",
@@ -1116,8 +1116,8 @@ func (n *FastNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		return CmpPrefix(a.Cidr, b.Cidr)
 	})
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// for all direct item under this node ...
 	for i, item := range directItems {

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -839,8 +839,8 @@ func (n *LiteNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 	bits := depth * strideLen
 	indent := strings.Repeat(".", depth)
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// node type with depth and octet path and bits.
 	fmt.Fprintf(w, "\n%s[%s] depth:  %d path: [%s] / %d\n",
@@ -1116,8 +1116,8 @@ func (n *LiteNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		return CmpPrefix(a.Cidr, b.Cidr)
 	})
 
-	// printing values if V is not zero-sized
-	printValues := !value.IsZST[V]()
+	// printing values if V is not the empty struct{}
+	printValues := !value.IsEmptyStruct[V]()
 
 	// for all direct item under this node ...
 	for i, item := range directItems {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -6,12 +6,11 @@
 //
 // The package offers three main categories of utilities:
 //
-// # Zero-Sized Type (ZST) Detection
+// # V as type struct{} Detection
 //
-// IsZST[V] detects whether a type parameter V is a zero-sized type (such as
-// `struct{}` or `[0]byte`). Zero-sized types carry no information in their
-// values. Omitting them from dumps and prints reduces line noise and
-// improves readability.
+// IsEmptyStruct[V] detects whether a type parameter V is a `struct{}`. These
+// types carry no information in their values. Omitting them from dumps
+// and prints reduces line noise and improves readability.
 //
 // # Value Equality
 //
@@ -33,13 +32,11 @@ import (
 	"reflect"
 )
 
-// IsZST reports whether type V is a zero-sized type (ZST).
-//
-// Zero-sized types such as `struct{}`, `[0]byte`, or structs/arrays with no fields
-// occupy no memory. This function uses reflection to determine the size of the
-// type safely without relying on the unsafe package.
-func IsZST[V any]() bool {
-	return reflect.TypeFor[V]().Size() == 0
+// IsEmptyStruct reports whether type V is the unnamed empty struct type `struct{}`.
+func IsEmptyStruct[V any]() bool {
+	var zero V
+	_, ok := any(zero).(struct{})
+	return ok
 }
 
 // Equal compares two values of type V for equality.

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -5,109 +5,106 @@ import (
 )
 
 // ============================================================================
-// Helper Types for Testing IsZST
+// Helper Types for Testing IsEmptyStruct
 // ============================================================================
 
-type EmptyStruct struct{}
+// NamedEmpty is a named type defined as struct{}.
+// It occupies 0 bytes, but is distinct from the unnamed struct{}.
+type NamedEmpty struct{}
 
-type EmptyStructWrapper struct {
-	A EmptyStruct
-	B [0]int
+type NonEmpty struct {
+	Value int
 }
 
-type NonEmptyStruct struct {
-	Field int
-}
-
-func TestIsZST(t *testing.T) {
+func TestIsEmptyStruct(t *testing.T) {
 	tests := []struct {
 		name string
 		run  func(t *testing.T)
 	}{
 		// --------------------------------------------------------------------
-		// Zero-Sized Types (Expect true)
+		// Positive Case (Expect true)
 		// --------------------------------------------------------------------
 		{
-			name: "empty struct struct{} is ZST",
+			name: "unnamed empty struct struct{} returns true",
 			run: func(t *testing.T) {
-				if !IsZST[struct{}]() {
-					t.Errorf("expected IsZST[struct{}]() to be true")
-				}
-			},
-		},
-		{
-			name: "named empty struct is ZST",
-			run: func(t *testing.T) {
-				if !IsZST[EmptyStruct]() {
-					t.Errorf("expected IsZST[EmptyStruct]() to be true")
-				}
-			},
-		},
-		{
-			name: "struct containing only ZST fields is ZST",
-			run: func(t *testing.T) {
-				if !IsZST[EmptyStructWrapper]() {
-					t.Errorf("expected IsZST[EmptyStructWrapper]() to be true")
-				}
-			},
-		},
-		{
-			name: "zero-length array [0]byte is ZST",
-			run: func(t *testing.T) {
-				if !IsZST[[0]byte]() {
-					t.Errorf("expected IsZST[[0]byte]() to be true")
-				}
-			},
-		},
-		{
-			name: "array of zero-sized elements [5]struct{} is ZST",
-			run: func(t *testing.T) {
-				if !IsZST[[5]struct{}]() {
-					t.Errorf("expected IsZST[[5]struct{}]() to be true")
+				if !IsEmptyStruct[struct{}]() {
+					t.Errorf("expected IsEmptyStruct[struct{}]() to be true")
 				}
 			},
 		},
 
 		// --------------------------------------------------------------------
-		// Non-Zero-Sized Types (Expect false)
+		// Negative Cases (Expect false)
 		// --------------------------------------------------------------------
 		{
-			name: "primitive type int is non-ZST",
+			name: "named empty struct returns false (distinct type from struct{})",
 			run: func(t *testing.T) {
-				if IsZST[int]() {
-					t.Errorf("expected IsZST[int]() to be false")
+				if IsEmptyStruct[NamedEmpty]() {
+					t.Errorf("expected IsEmptyStruct[NamedEmpty]() to be false")
 				}
 			},
 		},
 		{
-			name: "struct with non-ZST fields is non-ZST",
+			name: "primitive type int returns false",
 			run: func(t *testing.T) {
-				if IsZST[NonEmptyStruct]() {
-					t.Errorf("expected IsZST[NonEmptyStruct]() to be false")
+				if IsEmptyStruct[int]() {
+					t.Errorf("expected IsEmptyStruct[int]() to be false")
 				}
 			},
 		},
 		{
-			name: "pointer to ZST *struct{} is non-ZST (occupies pointer size)",
+			name: "primitive type string returns false",
 			run: func(t *testing.T) {
-				if IsZST[*struct{}]() {
-					t.Errorf("expected IsZST[*struct{}]() to be false")
+				if IsEmptyStruct[string]() {
+					t.Errorf("expected IsEmptyStruct[string]() to be false")
 				}
 			},
 		},
 		{
-			name: "slice of ZST []struct{} is non-ZST (occupies slice header size)",
+			name: "non-empty struct returns false",
 			run: func(t *testing.T) {
-				if IsZST[[]struct{}]() {
-					t.Errorf("expected IsZST[[]struct{}]() to be false")
+				if IsEmptyStruct[NonEmpty]() {
+					t.Errorf("expected IsEmptyStruct[NonEmpty]() to be false")
 				}
 			},
 		},
 		{
-			name: "interface type any is non-ZST (occupies interface header size)",
+			name: "zero-sized array [0]byte returns false (is ZST, but not struct{})",
 			run: func(t *testing.T) {
-				if IsZST[any]() {
-					t.Errorf("expected IsZST[any]() to be false")
+				if IsEmptyStruct[[0]byte]() {
+					t.Errorf("expected IsEmptyStruct[[0]byte]() to be false")
+				}
+			},
+		},
+		{
+			name: "array of empty structs [1]struct{} returns false",
+			run: func(t *testing.T) {
+				if IsEmptyStruct[[1]struct{}]() {
+					t.Errorf("expected IsEmptyStruct[[1]struct{}]() to be false")
+				}
+			},
+		},
+		{
+			name: "pointer to empty struct *struct{} returns false",
+			run: func(t *testing.T) {
+				if IsEmptyStruct[*struct{}]() {
+					t.Errorf("expected IsEmptyStruct[*struct{}]() to be false")
+				}
+			},
+		},
+		{
+			name: "interface type any returns false",
+			run: func(t *testing.T) {
+				if IsEmptyStruct[any]() {
+					t.Errorf("expected IsEmptyStruct[any]() to be false")
+				}
+			},
+		},
+		{
+			name: "slice of empty structs []struct{} returns false",
+			run: func(t *testing.T) {
+				if IsEmptyStruct[[]struct{}]() {
+					t.Errorf("expected IsEmptyStruct[[]struct{}]() to be false")
 				}
 			},
 		},


### PR DESCRIPTION
@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trie debug and formatted output for stored values.
  * Value rendering is now suppressed/printed based specifically on empty-struct (`struct{}`) semantics, rather than all zero-sized types.

* **Tests**
  * Updated and expanded coverage to validate the new empty-struct behavior, including named empty structs, non-empty structs, and checks covering pointers, interfaces, slices, and other zero-sized cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->