### PR TITLE
gen: omit value checks in EqualRec for LiteNode

### DIFF
--- a/internal/nodes/bartmethodsgenerated.go
+++ b/internal/nodes/bartmethodsgenerated.go
@@ -746,14 +746,14 @@ func (n *BartNode[V]) EqualRec(o *BartNode[V]) bool {
 	}
 
 	for idx, nVal := range n.AllIndices() {
-		oVal := o.MustGetPrefix(idx) // mustGet is ok, bitsets are equal
+		oVal := o.MustGetPrefix(idx) // MustGet is ok, bitsets are equal
 		if !value.Equal(nVal, oVal) {
 			return false
 		}
 	}
 
 	for addr, nKid := range n.AllChildren() {
-		oKid := o.MustGetChild(addr) // mustGet is ok, bitsets are equal
+		oKid := o.MustGetChild(addr) // MustGet is ok, bitsets are equal
 
 		switch nKid := nKid.(type) {
 		case *BartNode[V]:
@@ -791,6 +791,7 @@ func (n *BartNode[V]) EqualRec(o *BartNode[V]) bool {
 			if !ok {
 				return false
 			}
+			_ = oKid // mark as used for LiteNode (where value checks are stripped)
 
 			// compare values
 			if !value.Equal(nKid.Value, oKid.Value) {
@@ -863,7 +864,7 @@ func (n *BartNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 		fmt.Fprintln(w)
 
-		// skip printing values if V is zero-sized
+		// skip printing values if V is empty struct
 		if printValues {
 
 			// print the values for this node
@@ -914,7 +915,7 @@ func (n *BartNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 			for _, addr := range leafAddrs {
 				kid := n.MustGetChild(addr).(*LeafNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), kid.Prefix, kid.Value)
 				} else {
@@ -934,7 +935,7 @@ func (n *BartNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 				kid := n.MustGetChild(addr).(*FringeNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), fringePfx, kid.Value)
 				} else {
@@ -1136,7 +1137,7 @@ func (n *BartNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		if printValues {
 			_, err = fmt.Fprintf(w, "%s%s (%v)\n", pad+glyph, item.Cidr, item.Val)
 		} else {
-			// skip printing values if V is zero-sized
+			// skip printing values if V is empty struct
 			_, err = fmt.Fprintf(w, "%s%s\n", pad+glyph, item.Cidr)
 		}
 

--- a/internal/nodes/barttestsgenerated_test.go
+++ b/internal/nodes/barttestsgenerated_test.go
@@ -607,8 +607,8 @@ func TestSubnets6_BartNode(t *testing.T) {
 	}
 }
 
-// TestDump_ZST verifies that dump does not print values when V is a zero-sized type.
-func TestDump_ZST_BartNode(t *testing.T) {
+// TestDump_EMPTY_STRUCT verifies that dump does not print values when V is a empty struct type.
+func TestDump_EMPTY_STRUCT_BartNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(BartNode[struct{}])
@@ -623,19 +623,19 @@ func TestDump_ZST_BartNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, dump should print prefixes(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefixes(#N) but skip the "values(#N):" section
 	if !strings.Contains(output, "prefxs(") {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For ZST, dump should print prefxs(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefxs(#N) but skip the "values(#N):" section
 	if strings.Contains(output, "values(") {
-		t.Errorf("Expected no 'values()' section for ZST, but found it in:\n%s", output)
+		t.Errorf("Expected no 'values()' section for EMPTY_STRUCT, but found it in:\n%s", output)
 	}
 }
 
-// TestDump_NonZST verifies that dump prints values when V is not a zero-sized type.
-func TestDump_NonZST_BartNode(t *testing.T) {
+// TestDump_NonEMPTY_STRUCT verifies that dump prints values when V is not a empty struct type.
+func TestDump_NonEMPTY_STRUCT_BartNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(BartNode[int])
@@ -659,9 +659,9 @@ func TestDump_NonZST_BartNode(t *testing.T) {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For non-ZST, dump should include the "values(#N):" section
+	// For non-EMPTY_STRUCT, dump should include the "values(#N):" section
 	if !strings.Contains(output, "values(") {
-		t.Errorf("Expected 'values()' section for non-ZST, but not found in:\n%s", output)
+		t.Errorf("Expected 'values()' section for non-EMPTY_STRUCT, but not found in:\n%s", output)
 	}
 
 	// Should contain the actual value
@@ -670,8 +670,8 @@ func TestDump_NonZST_BartNode(t *testing.T) {
 	}
 }
 
-// TestFprintRec_ZST verifies FprintRec does not print values for zero-sized types.
-func TestFprintRec_ZST_BartNode(t *testing.T) {
+// TestFprintRec_EMPTY_STRUCT verifies FprintRec does not print values for empty struct types.
+func TestFprintRec_EMPTY_STRUCT_BartNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(BartNode[struct{}])
@@ -695,14 +695,14 @@ func TestFprintRec_ZST_BartNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, output should show prefix but no value in parentheses
+	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
-		t.Errorf("Expected no value in parentheses for ZST prefix, but found in:\n%s", output)
+		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)
 	}
 }
 
-// TestFprintRec_NonZST verifies FprintRec prints values for non-zero-sized types.
-func TestFprintRec_NonZST_BartNode(t *testing.T) {
+// TestFprintRec_NonEMPTY_STRUCT verifies FprintRec prints values for non-empty struct types.
+func TestFprintRec_NonEMPTY_STRUCT_BartNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(BartNode[string])
@@ -733,7 +733,7 @@ func TestFprintRec_NonZST_BartNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For non-ZST, output should show both prefix and value
+	// For non-EMPTY_STRUCT, output should show both prefix and value
 	if !strings.Contains(output, "10.0.0.0/7") || !strings.Contains(output, "testval") {
 		t.Errorf("Expected prefix and value 'testval' in output, but got:\n%s", output)
 	}

--- a/internal/nodes/barttestsgenerated_test.go
+++ b/internal/nodes/barttestsgenerated_test.go
@@ -695,6 +695,10 @@ func TestFprintRec_EMPTY_STRUCT_BartNode(t *testing.T) {
 
 	output := buf.String()
 
+	if !strings.Contains(output, pfx.String()) {
+		t.Errorf("Expected '%s' in output, got:\n%s", pfx, output)
+	}
+
 	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
 		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)

--- a/internal/nodes/commonmethods_tmpl.go
+++ b/internal/nodes/commonmethods_tmpl.go
@@ -779,15 +779,17 @@ func (n *_NODE_TYPE[V]) EqualRec(o *_NODE_TYPE[V]) bool {
 		return false
 	}
 
+	// ### GENERATE SKIP_LITE START ###
 	for idx, nVal := range n.AllIndices() {
-		oVal := o.MustGetPrefix(idx) // mustGet is ok, bitsets are equal
+		oVal := o.MustGetPrefix(idx) // MustGet is ok, bitsets are equal
 		if !value.Equal(nVal, oVal) {
 			return false
 		}
 	}
+	// ### GENERATE SKIP_LITE END ###
 
 	for addr, nKid := range n.AllChildren() {
-		oKid := o.MustGetChild(addr) // mustGet is ok, bitsets are equal
+		oKid := o.MustGetChild(addr) // MustGet is ok, bitsets are equal
 
 		switch nKid := nKid.(type) {
 		case *_NODE_TYPE[V]:
@@ -814,10 +816,14 @@ func (n *_NODE_TYPE[V]) EqualRec(o *_NODE_TYPE[V]) bool {
 				return false
 			}
 
+			// ### GENERATE SKIP_LITE START ###
+
 			// compare values
 			if !value.Equal(nKid.Value, oKid.Value) {
 				return false
 			}
+
+			// ### GENERATE SKIP_LITE END ###
 
 		case *FringeNode[V]:
 			// oKid must also be a fringe
@@ -825,11 +831,16 @@ func (n *_NODE_TYPE[V]) EqualRec(o *_NODE_TYPE[V]) bool {
 			if !ok {
 				return false
 			}
+			_ = oKid // mark as used for LiteNode (where value checks are stripped)
+
+			// ### GENERATE SKIP_LITE START ###
 
 			// compare values
 			if !value.Equal(nKid.Value, oKid.Value) {
 				return false
 			}
+
+			// ### GENERATE SKIP_LITE END ###
 
 		default:
 			panic("logic error, wrong node type")
@@ -897,7 +908,7 @@ func (n *_NODE_TYPE[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) 
 
 		fmt.Fprintln(w)
 
-		// skip printing values if V is zero-sized
+		// skip printing values if V is empty struct
 		if printValues {
 
 			// print the values for this node
@@ -948,7 +959,7 @@ func (n *_NODE_TYPE[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) 
 			for _, addr := range leafAddrs {
 				kid := n.MustGetChild(addr).(*LeafNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), kid.Prefix, kid.Value)
 				} else {
@@ -968,7 +979,7 @@ func (n *_NODE_TYPE[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) 
 
 				kid := n.MustGetChild(addr).(*FringeNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), fringePfx, kid.Value)
 				} else {
@@ -1170,7 +1181,7 @@ func (n *_NODE_TYPE[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) e
 		if printValues {
 			_, err = fmt.Fprintf(w, "%s%s (%v)\n", pad+glyph, item.Cidr, item.Val)
 		} else {
-			// skip printing values if V is zero-sized
+			// skip printing values if V is empty struct
 			_, err = fmt.Fprintf(w, "%s%s\n", pad+glyph, item.Cidr)
 		}
 

--- a/internal/nodes/commontests_tmpl.go
+++ b/internal/nodes/commontests_tmpl.go
@@ -723,6 +723,10 @@ func TestFprintRec_EMPTY_STRUCT__NODE_TYPE(t *testing.T) {
 
 	output := buf.String()
 
+	if !strings.Contains(output, pfx.String()) {
+		t.Errorf("Expected '%s' in output, got:\n%s", pfx, output)
+	}
+
 	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
 		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)

--- a/internal/nodes/commontests_tmpl.go
+++ b/internal/nodes/commontests_tmpl.go
@@ -635,8 +635,8 @@ func TestSubnets6__NODE_TYPE(t *testing.T) {
 	}
 }
 
-// TestDump_ZST verifies that dump does not print values when V is a zero-sized type.
-func TestDump_ZST__NODE_TYPE(t *testing.T) {
+// TestDump_EMPTY_STRUCT verifies that dump does not print values when V is a empty struct type.
+func TestDump_EMPTY_STRUCT__NODE_TYPE(t *testing.T) {
 	t.Parallel()
 
 	node := new(_NODE_TYPE[struct{}])
@@ -651,19 +651,19 @@ func TestDump_ZST__NODE_TYPE(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, dump should print prefixes(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefixes(#N) but skip the "values(#N):" section
 	if !strings.Contains(output, "prefxs(") {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For ZST, dump should print prefxs(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefxs(#N) but skip the "values(#N):" section
 	if strings.Contains(output, "values(") {
-		t.Errorf("Expected no 'values()' section for ZST, but found it in:\n%s", output)
+		t.Errorf("Expected no 'values()' section for EMPTY_STRUCT, but found it in:\n%s", output)
 	}
 }
 
-// TestDump_NonZST verifies that dump prints values when V is not a zero-sized type.
-func TestDump_NonZST__NODE_TYPE(t *testing.T) {
+// TestDump_NonEMPTY_STRUCT verifies that dump prints values when V is not a empty struct type.
+func TestDump_NonEMPTY_STRUCT__NODE_TYPE(t *testing.T) {
 	t.Parallel()
 
 	node := new(_NODE_TYPE[int])
@@ -687,9 +687,9 @@ func TestDump_NonZST__NODE_TYPE(t *testing.T) {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For non-ZST, dump should include the "values(#N):" section
+	// For non-EMPTY_STRUCT, dump should include the "values(#N):" section
 	if !strings.Contains(output, "values(") {
-		t.Errorf("Expected 'values()' section for non-ZST, but not found in:\n%s", output)
+		t.Errorf("Expected 'values()' section for non-EMPTY_STRUCT, but not found in:\n%s", output)
 	}
 
 	// Should contain the actual value
@@ -698,8 +698,8 @@ func TestDump_NonZST__NODE_TYPE(t *testing.T) {
 	}
 }
 
-// TestFprintRec_ZST verifies FprintRec does not print values for zero-sized types.
-func TestFprintRec_ZST__NODE_TYPE(t *testing.T) {
+// TestFprintRec_EMPTY_STRUCT verifies FprintRec does not print values for empty struct types.
+func TestFprintRec_EMPTY_STRUCT__NODE_TYPE(t *testing.T) {
 	t.Parallel()
 
 	node := new(_NODE_TYPE[struct{}])
@@ -723,14 +723,14 @@ func TestFprintRec_ZST__NODE_TYPE(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, output should show prefix but no value in parentheses
+	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
-		t.Errorf("Expected no value in parentheses for ZST prefix, but found in:\n%s", output)
+		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)
 	}
 }
 
-// TestFprintRec_NonZST verifies FprintRec prints values for non-zero-sized types.
-func TestFprintRec_NonZST__NODE_TYPE(t *testing.T) {
+// TestFprintRec_NonEMPTY_STRUCT verifies FprintRec prints values for non-empty struct types.
+func TestFprintRec_NonEMPTY_STRUCT__NODE_TYPE(t *testing.T) {
 	t.Parallel()
 
 	node := new(_NODE_TYPE[string])
@@ -761,7 +761,7 @@ func TestFprintRec_NonZST__NODE_TYPE(t *testing.T) {
 
 	output := buf.String()
 
-	// For non-ZST, output should show both prefix and value
+	// For non-EMPTY_STRUCT, output should show both prefix and value
 	if !strings.Contains(output, "10.0.0.0/7") || !strings.Contains(output, "testval") {
 		t.Errorf("Expected prefix and value 'testval' in output, but got:\n%s", output)
 	}

--- a/internal/nodes/fastmethodsgenerated.go
+++ b/internal/nodes/fastmethodsgenerated.go
@@ -746,14 +746,14 @@ func (n *FastNode[V]) EqualRec(o *FastNode[V]) bool {
 	}
 
 	for idx, nVal := range n.AllIndices() {
-		oVal := o.MustGetPrefix(idx) // mustGet is ok, bitsets are equal
+		oVal := o.MustGetPrefix(idx) // MustGet is ok, bitsets are equal
 		if !value.Equal(nVal, oVal) {
 			return false
 		}
 	}
 
 	for addr, nKid := range n.AllChildren() {
-		oKid := o.MustGetChild(addr) // mustGet is ok, bitsets are equal
+		oKid := o.MustGetChild(addr) // MustGet is ok, bitsets are equal
 
 		switch nKid := nKid.(type) {
 		case *FastNode[V]:
@@ -791,6 +791,7 @@ func (n *FastNode[V]) EqualRec(o *FastNode[V]) bool {
 			if !ok {
 				return false
 			}
+			_ = oKid // mark as used for LiteNode (where value checks are stripped)
 
 			// compare values
 			if !value.Equal(nKid.Value, oKid.Value) {
@@ -863,7 +864,7 @@ func (n *FastNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 		fmt.Fprintln(w)
 
-		// skip printing values if V is zero-sized
+		// skip printing values if V is empty struct
 		if printValues {
 
 			// print the values for this node
@@ -914,7 +915,7 @@ func (n *FastNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 			for _, addr := range leafAddrs {
 				kid := n.MustGetChild(addr).(*LeafNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), kid.Prefix, kid.Value)
 				} else {
@@ -934,7 +935,7 @@ func (n *FastNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 				kid := n.MustGetChild(addr).(*FringeNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), fringePfx, kid.Value)
 				} else {
@@ -1136,7 +1137,7 @@ func (n *FastNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		if printValues {
 			_, err = fmt.Fprintf(w, "%s%s (%v)\n", pad+glyph, item.Cidr, item.Val)
 		} else {
-			// skip printing values if V is zero-sized
+			// skip printing values if V is empty struct
 			_, err = fmt.Fprintf(w, "%s%s\n", pad+glyph, item.Cidr)
 		}
 

--- a/internal/nodes/fasttestsgenerated_test.go
+++ b/internal/nodes/fasttestsgenerated_test.go
@@ -607,8 +607,8 @@ func TestSubnets6_FastNode(t *testing.T) {
 	}
 }
 
-// TestDump_ZST verifies that dump does not print values when V is a zero-sized type.
-func TestDump_ZST_FastNode(t *testing.T) {
+// TestDump_EMPTY_STRUCT verifies that dump does not print values when V is a empty struct type.
+func TestDump_EMPTY_STRUCT_FastNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(FastNode[struct{}])
@@ -623,19 +623,19 @@ func TestDump_ZST_FastNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, dump should print prefixes(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefixes(#N) but skip the "values(#N):" section
 	if !strings.Contains(output, "prefxs(") {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For ZST, dump should print prefxs(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefxs(#N) but skip the "values(#N):" section
 	if strings.Contains(output, "values(") {
-		t.Errorf("Expected no 'values()' section for ZST, but found it in:\n%s", output)
+		t.Errorf("Expected no 'values()' section for EMPTY_STRUCT, but found it in:\n%s", output)
 	}
 }
 
-// TestDump_NonZST verifies that dump prints values when V is not a zero-sized type.
-func TestDump_NonZST_FastNode(t *testing.T) {
+// TestDump_NonEMPTY_STRUCT verifies that dump prints values when V is not a empty struct type.
+func TestDump_NonEMPTY_STRUCT_FastNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(FastNode[int])
@@ -659,9 +659,9 @@ func TestDump_NonZST_FastNode(t *testing.T) {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For non-ZST, dump should include the "values(#N):" section
+	// For non-EMPTY_STRUCT, dump should include the "values(#N):" section
 	if !strings.Contains(output, "values(") {
-		t.Errorf("Expected 'values()' section for non-ZST, but not found in:\n%s", output)
+		t.Errorf("Expected 'values()' section for non-EMPTY_STRUCT, but not found in:\n%s", output)
 	}
 
 	// Should contain the actual value
@@ -670,8 +670,8 @@ func TestDump_NonZST_FastNode(t *testing.T) {
 	}
 }
 
-// TestFprintRec_ZST verifies FprintRec does not print values for zero-sized types.
-func TestFprintRec_ZST_FastNode(t *testing.T) {
+// TestFprintRec_EMPTY_STRUCT verifies FprintRec does not print values for empty struct types.
+func TestFprintRec_EMPTY_STRUCT_FastNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(FastNode[struct{}])
@@ -695,14 +695,14 @@ func TestFprintRec_ZST_FastNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, output should show prefix but no value in parentheses
+	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
-		t.Errorf("Expected no value in parentheses for ZST prefix, but found in:\n%s", output)
+		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)
 	}
 }
 
-// TestFprintRec_NonZST verifies FprintRec prints values for non-zero-sized types.
-func TestFprintRec_NonZST_FastNode(t *testing.T) {
+// TestFprintRec_NonEMPTY_STRUCT verifies FprintRec prints values for non-empty struct types.
+func TestFprintRec_NonEMPTY_STRUCT_FastNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(FastNode[string])
@@ -733,7 +733,7 @@ func TestFprintRec_NonZST_FastNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For non-ZST, output should show both prefix and value
+	// For non-EMPTY_STRUCT, output should show both prefix and value
 	if !strings.Contains(output, "10.0.0.0/7") || !strings.Contains(output, "testval") {
 		t.Errorf("Expected prefix and value 'testval' in output, but got:\n%s", output)
 	}

--- a/internal/nodes/fasttestsgenerated_test.go
+++ b/internal/nodes/fasttestsgenerated_test.go
@@ -695,6 +695,10 @@ func TestFprintRec_EMPTY_STRUCT_FastNode(t *testing.T) {
 
 	output := buf.String()
 
+	if !strings.Contains(output, pfx.String()) {
+		t.Errorf("Expected '%s' in output, got:\n%s", pfx, output)
+	}
+
 	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
 		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)

--- a/internal/nodes/litemethodsgenerated.go
+++ b/internal/nodes/litemethodsgenerated.go
@@ -745,15 +745,8 @@ func (n *LiteNode[V]) EqualRec(o *LiteNode[V]) bool {
 		return false
 	}
 
-	for idx, nVal := range n.AllIndices() {
-		oVal := o.MustGetPrefix(idx) // mustGet is ok, bitsets are equal
-		if !value.Equal(nVal, oVal) {
-			return false
-		}
-	}
-
 	for addr, nKid := range n.AllChildren() {
-		oKid := o.MustGetChild(addr) // mustGet is ok, bitsets are equal
+		oKid := o.MustGetChild(addr) // MustGet is ok, bitsets are equal
 
 		switch nKid := nKid.(type) {
 		case *LiteNode[V]:
@@ -780,22 +773,13 @@ func (n *LiteNode[V]) EqualRec(o *LiteNode[V]) bool {
 				return false
 			}
 
-			// compare values
-			if !value.Equal(nKid.Value, oKid.Value) {
-				return false
-			}
-
 		case *FringeNode[V]:
 			// oKid must also be a fringe
 			oKid, ok := oKid.(*FringeNode[V])
 			if !ok {
 				return false
 			}
-
-			// compare values
-			if !value.Equal(nKid.Value, oKid.Value) {
-				return false
-			}
+			_ = oKid // mark as used for LiteNode (where value checks are stripped)
 
 		default:
 			panic("logic error, wrong node type")
@@ -863,7 +847,7 @@ func (n *LiteNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 		fmt.Fprintln(w)
 
-		// skip printing values if V is zero-sized
+		// skip printing values if V is empty struct
 		if printValues {
 
 			// print the values for this node
@@ -914,7 +898,7 @@ func (n *LiteNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 			for _, addr := range leafAddrs {
 				kid := n.MustGetChild(addr).(*LeafNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), kid.Prefix, kid.Value)
 				} else {
@@ -934,7 +918,7 @@ func (n *LiteNode[V]) dump(w io.Writer, path StridePath, depth int, is4 bool) {
 
 				kid := n.MustGetChild(addr).(*FringeNode[V])
 
-				// skip printing values if V is zero-sized
+				// skip printing values if V is empty struct
 				if printValues {
 					fmt.Fprintf(w, " %s:{%s, %v}", addrFmt(addr, is4), fringePfx, kid.Value)
 				} else {
@@ -1136,7 +1120,7 @@ func (n *LiteNode[V]) FprintRec(w io.Writer, parent TrieItem[V], pad string) err
 		if printValues {
 			_, err = fmt.Fprintf(w, "%s%s (%v)\n", pad+glyph, item.Cidr, item.Val)
 		} else {
-			// skip printing values if V is zero-sized
+			// skip printing values if V is empty struct
 			_, err = fmt.Fprintf(w, "%s%s\n", pad+glyph, item.Cidr)
 		}
 

--- a/internal/nodes/litetestsgenerated_test.go
+++ b/internal/nodes/litetestsgenerated_test.go
@@ -607,8 +607,8 @@ func TestSubnets6_LiteNode(t *testing.T) {
 	}
 }
 
-// TestDump_ZST verifies that dump does not print values when V is a zero-sized type.
-func TestDump_ZST_LiteNode(t *testing.T) {
+// TestDump_EMPTY_STRUCT verifies that dump does not print values when V is a empty struct type.
+func TestDump_EMPTY_STRUCT_LiteNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(LiteNode[struct{}])
@@ -623,19 +623,19 @@ func TestDump_ZST_LiteNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, dump should print prefixes(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefixes(#N) but skip the "values(#N):" section
 	if !strings.Contains(output, "prefxs(") {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For ZST, dump should print prefxs(#N) but skip the "values(#N):" section
+	// For EMPTY_STRUCT, dump should print prefxs(#N) but skip the "values(#N):" section
 	if strings.Contains(output, "values(") {
-		t.Errorf("Expected no 'values()' section for ZST, but found it in:\n%s", output)
+		t.Errorf("Expected no 'values()' section for EMPTY_STRUCT, but found it in:\n%s", output)
 	}
 }
 
-// TestDump_NonZST verifies that dump prints values when V is not a zero-sized type.
-func TestDump_NonZST_LiteNode(t *testing.T) {
+// TestDump_NonEMPTY_STRUCT verifies that dump prints values when V is not a empty struct type.
+func TestDump_NonEMPTY_STRUCT_LiteNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(LiteNode[int])
@@ -659,9 +659,9 @@ func TestDump_NonZST_LiteNode(t *testing.T) {
 		t.Errorf("Expected 'prefxs()' section, but not found in:\n%s", output)
 	}
 
-	// For non-ZST, dump should include the "values(#N):" section
+	// For non-EMPTY_STRUCT, dump should include the "values(#N):" section
 	if !strings.Contains(output, "values(") {
-		t.Errorf("Expected 'values()' section for non-ZST, but not found in:\n%s", output)
+		t.Errorf("Expected 'values()' section for non-EMPTY_STRUCT, but not found in:\n%s", output)
 	}
 
 	// Should contain the actual value
@@ -670,8 +670,8 @@ func TestDump_NonZST_LiteNode(t *testing.T) {
 	}
 }
 
-// TestFprintRec_ZST verifies FprintRec does not print values for zero-sized types.
-func TestFprintRec_ZST_LiteNode(t *testing.T) {
+// TestFprintRec_EMPTY_STRUCT verifies FprintRec does not print values for empty struct types.
+func TestFprintRec_EMPTY_STRUCT_LiteNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(LiteNode[struct{}])
@@ -695,14 +695,14 @@ func TestFprintRec_ZST_LiteNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For ZST, output should show prefix but no value in parentheses
+	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
-		t.Errorf("Expected no value in parentheses for ZST prefix, but found in:\n%s", output)
+		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)
 	}
 }
 
-// TestFprintRec_NonZST verifies FprintRec prints values for non-zero-sized types.
-func TestFprintRec_NonZST_LiteNode(t *testing.T) {
+// TestFprintRec_NonEMPTY_STRUCT verifies FprintRec prints values for non-empty struct types.
+func TestFprintRec_NonEMPTY_STRUCT_LiteNode(t *testing.T) {
 	t.Parallel()
 
 	node := new(LiteNode[string])
@@ -733,7 +733,7 @@ func TestFprintRec_NonZST_LiteNode(t *testing.T) {
 
 	output := buf.String()
 
-	// For non-ZST, output should show both prefix and value
+	// For non-EMPTY_STRUCT, output should show both prefix and value
 	if !strings.Contains(output, "10.0.0.0/7") || !strings.Contains(output, "testval") {
 		t.Errorf("Expected prefix and value 'testval' in output, but got:\n%s", output)
 	}

--- a/internal/nodes/litetestsgenerated_test.go
+++ b/internal/nodes/litetestsgenerated_test.go
@@ -695,6 +695,10 @@ func TestFprintRec_EMPTY_STRUCT_LiteNode(t *testing.T) {
 
 	output := buf.String()
 
+	if !strings.Contains(output, pfx.String()) {
+		t.Errorf("Expected '%s' in output, got:\n%s", pfx, output)
+	}
+
 	// For EMPTY_STRUCT, output should show prefix but no value in parentheses
 	if strings.Contains(output, "10.0.0.0/7 (") || strings.Contains(output, "10.0.0.0/7(") {
 		t.Errorf("Expected no value in parentheses for EMPTY_STRUCT prefix, but found in:\n%s", output)

--- a/scripts/generate-node-methods.sh
+++ b/scripts/generate-node-methods.sh
@@ -37,12 +37,23 @@ for nodeType in "${NODE_TYPES[@]}"; do
     base_mangled="${template_base/_tmpl/generated}"               # -> methodsgenerated.go
     output_file="${type_prefix}${base_mangled}"                   # e.g. -> bartmethodsgenerated.go
 
+    # Use an array to pass flags and expressions safely to sed without quote-splitting issues
+    lite_filter=()
+    if [[ "${nodeType,,}" == *lite* ]]; then
+        # Delete all lines between the markers (inclusive) for LiteNode
+        lite_filter+=(-e '/GENERATE SKIP_LITE START/,/GENERATE SKIP_LITE END/d')
+    else
+        # For Table/Fast nodes, keep the enclosed code and remove only the marker comment lines
+        lite_filter+=(-e '/GENERATE SKIP_LITE/d')
+    fi
+
     # Remove go:generate directives and build constraint, add generated header, substitute node type
     sed -e "1i\\
 // Code generated from file \"${template_file}\"; DO NOT EDIT." \
         -e '/^\/\/go:build generate\b/d' \
         -e '/^\/\/go:generate\b/d' \
         -e '/GENERATE DELETE START/,/GENERATE DELETE END/d' \
+        "${lite_filter[@]}" \
         -e "s|_NODE_TYPE|${nodeType}|g" \
         "${template_file}" > "${output_file}"
     


### PR DESCRIPTION
Introduce GENERATE SKIP_LITE markers in commonmethods_tmpl.go to strip value equality checks for LiteNode during code generation. LiteNode only tracks structural set presence and carries no values.

Updated generate-node-methods.sh to parse the markers via sed and added a blank assignment to suppress 'declared and not used' compiler errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lightweight trie node equality behavior by skipping value comparisons in the appropriate “lite” scenarios.
  * Refined dump/print output expectations for empty struct payloads: prefixes remain, while value sections are omitted when appropriate.
* **Tests**
  * Updated and renamed dump and print tests to distinguish `struct{}` (“empty struct”) from other zero-sized types.
  * Adjusted assertions to verify presence/absence of the `values(...)` portion and correct value text for non-empty payloads.
* **Chores**
  * Improved node-method generation filtering to make handling of lite variants more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->