### PR TITLE
Consolidate gosec Suppressions and Remove Obsolete SIMD Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,6 @@ func (b *BitSet256) popcnt() (cnt int) {
   return
 }
 ```
-Future Go versions with SIMD intrinsics for `uint64` vectors may unlock
-additional speedups on compatible hardware.
 
 ## Concurrency model
 

--- a/internal/art/base_index.go
+++ b/internal/art/base_index.go
@@ -62,7 +62,7 @@ func IdxToPfx(idx uint8) (octet, pfxLen uint8) {
 	// so we subtract 1 to recover the prefix length (which is always >= 0).
 	// Invariant: idx==0 is invalid
 
-	//nolint:gosec  //G115: integer overflow conversion int -> uint8 (gosec)
+	//nolint:gosec  //G115: integer overflow conversion int -> uint8
 	pfxLen = uint8(bits.Len8(idx)) - 1
 
 	// Compute the number of bits to shift back to obtain the original octet.

--- a/internal/bitset/bitset256.go
+++ b/internal/bitset/bitset256.go
@@ -12,8 +12,6 @@
 // Internally, the bitset is represented by four uint64 words, providing
 // fast bit-level access through direct indexing and hardware-accelerated primitives.
 //
-// If Go eventually supports SIMD intrinsics, this can be further optimized.
-//
 // For external consumers, the API intentionally avoids dynamic allocation except
 // when explicitly requested (via Bits()).
 package bitset

--- a/internal/bitset/bitset256.go
+++ b/internal/bitset/bitset256.go
@@ -94,6 +94,8 @@ func (b *BitSet256) Test(bit uint8) (ok bool) {
 // the CPU to parallelize these operations internally (pipelining), avoiding
 // branch misprediction and maximizing instruction throughput. This technique
 // is especially effective for bitsets with known, fixed word count.
+//
+//nolint:gosec  // G115: integer overflow conversion int -> uint
 func (b *BitSet256) FirstSet() (first uint8, ok bool) {
 	// optimized for pipelining, can still inline with cost 79
 	x0 := bits.TrailingZeros64(b[0])
@@ -102,19 +104,15 @@ func (b *BitSet256) FirstSet() (first uint8, ok bool) {
 	x3 := bits.TrailingZeros64(b[3])
 
 	if x0 != 64 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(x0), true
 	}
 	if x1 != 64 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(x1 + 64), true
 	}
 	if x2 != 64 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(x2 + 128), true
 	}
 	if x3 != 64 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(x3 + 192), true
 	}
 
@@ -137,20 +135,20 @@ func (b *BitSet256) FirstSet() (first uint8, ok bool) {
 //	b.NextSet(5)   ->   5, true
 //	b.NextSet(6)   -> 130, true
 //	b.NextSet(200) ->   0, false
+//
+//nolint:gosec  // G115: integer overflow conversion int -> uint
 func (b *BitSet256) NextSet(bit uint8) (next uint8, ok bool) {
 	wIdx := int(bit >> 6)
 
 	// process the first (maybe partial) word
 	first := b[wIdx] >> (bit & 63)
 	if first != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return bit + uint8(bits.TrailingZeros64(first)), true
 	}
 
 	// process the following words until next bit is set
 	for wIdx++; wIdx < 4; wIdx++ {
 		if next := b[wIdx]; next != 0 {
-			//nolint:gosec  // G115: integer overflow conversion int -> uint
 			return uint8(wIdx<<6 + bits.TrailingZeros64(next)), true
 		}
 	}
@@ -170,23 +168,21 @@ func (b *BitSet256) NextSet(bit uint8) (next uint8, ok bool) {
 //	bs.Set(130)
 //	bs.Set(214)
 //	index, ok := bs.LastSet()  // index == 214, ok == true
+//
+//nolint:gosec  // G115: integer overflow conversion int -> uint
 func (b *BitSet256) LastSet() (last uint8, ok bool) {
 	// optimized by unrolling the loop.
 	// This enables compiler inlining and is ~20% faster.
 	if b[3] != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(bits.Len64(b[3]) + 191), true
 	}
 	if b[2] != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(bits.Len64(b[2]) + 127), true
 	}
 	if b[1] != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(bits.Len64(b[1]) + 63), true
 	}
 	if b[0] != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint
 		return uint8(bits.Len64(b[0]) - 1), true
 	}
 	return 0, false
@@ -205,11 +201,12 @@ func (b *BitSet256) LastSet() (last uint8, ok bool) {
 // The returned slice directly shares the underlying storage of `buf` and is only
 // valid until `buf` is modified or reused. This pattern is highly recommended for
 // hot paths and performance-critical loops where heap churn must be avoided.
+//
+//nolint:gosec  // G115: integer overflow conversion int -> uint
 func (b *BitSet256) AsSlice(buf *[256]uint8) []uint8 {
 	size := 0
 	for wIdx, word := range b {
 		for ; word != 0; size++ {
-			//nolint:gosec  // G115: integer overflow conversion int -> uint
 			buf[size] = uint8(wIdx<<6 + bits.TrailingZeros64(word))
 			word &= word - 1 // clear the rightmost set bit
 		}
@@ -239,16 +236,16 @@ func (b *BitSet256) Bits() []uint8 {
 // and returns the highest (top-most) set bit of the result.
 // If the intersection is non-empty, it returns the top bit index and true.
 // If the intersection is empty, ok is false and top is 0.
+//
+//nolint:gosec  // G115: integer overflow conversion int -> uint8
 func (b *BitSet256) IntersectionTop(c *BitSet256) (top uint8, ok bool) {
 	// optimized by unrolling the first word check.
 	// This enables compiler inlining and is ~15% faster.
 	if w := b[3] & c[3]; w != 0 {
-		//nolint:gosec  // G115: integer overflow conversion int -> uint8
 		return uint8(191 + bits.Len64(w)), true
 	}
 	for wIdx := 2; wIdx >= 0; wIdx-- {
 		if w := b[wIdx] & c[wIdx]; w != 0 {
-			//nolint:gosec  // G115: integer overflow conversion int -> uint8
 			return uint8(wIdx<<6 + bits.Len64(w) - 1), true
 		}
 	}

--- a/internal/nodes/nodebasics.go
+++ b/internal/nodes/nodebasics.go
@@ -298,9 +298,6 @@ func CidrForFringe(octets []byte, depth int, is4 bool, fringeByte uint8) netip.P
 //
 // If you can commit to a fixed size of [4]uint64, then the algorithm is
 // much faster due to modern CPUs.
-//
-// Perhaps a future Go version that supports SIMD instructions for the [4]uint64 vectors
-// will make the algorithm even faster on suitable hardware.
 func DivMod8(pfxLen int) (strideCount int, modBits uint8) {
 	// strideCount: range from 0..4 or 0..16
 	// modBits:     range from 0..7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated note about potential future SIMD performance improvements from the Bitset documentation.
  * Streamlined surrounding comments for bitset and utility functionality for clearer readability.

* **Chores**
  * Standardized static-analysis suppression comments related to integer-safety checks without affecting runtime behavior.
  * No public APIs or functional logic were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->