### PR TITLE
Add fast IPv4 and IPv6 prefix containment helpers

### DIFF
--- a/bartmethodsgenerated.go
+++ b/bartmethodsgenerated.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gaissmai/bart/internal/art"
+	"github.com/gaissmai/bart/internal/fastnetip"
 	"github.com/gaissmai/bart/internal/lpm"
 	"github.com/gaissmai/bart/internal/nodes"
 	"github.com/gaissmai/bart/internal/value"
@@ -74,7 +75,10 @@ func (f *Table[V]) Contains(ip netip.Addr) bool {
 			return true
 
 		case *nodes.LeafNode[V]:
-			return kid.Prefix.Contains(ip)
+			if is4 {
+				return fastnetip.Contains4(&kid.Prefix, &ip)
+			}
+			return fastnetip.Contains6(&kid.Prefix, &ip)
 		}
 	}
 
@@ -133,9 +137,16 @@ LOOP:
 			return kid.Value, true
 
 		case *nodes.LeafNode[V]:
-			if kid.Prefix.Contains(ip) {
-				return kid.Value, true
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
 			}
+
 			// reached a path compressed prefix, stop traversing
 			break LOOP
 		}
@@ -239,10 +250,20 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen {
 				break LOOP
 			}
-			return kid.Prefix, kid.Value, true
+
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			}
+			break LOOP
 
 		case *nodes.FringeNode[V]:
 			// the bits of the fringe are defined by the depth

--- a/commonmethods_tmpl.go
+++ b/commonmethods_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/gaissmai/bart/internal/art"
+	"github.com/gaissmai/bart/internal/fastnetip"
 	"github.com/gaissmai/bart/internal/lpm"
 	"github.com/gaissmai/bart/internal/nodes"
 	"github.com/gaissmai/bart/internal/value"
@@ -132,7 +133,10 @@ func (f *_TABLE_TYPE[V]) Contains(ip netip.Addr) bool {
 			return true
 
 		case *nodes.LeafNode[V]:
-			return kid.Prefix.Contains(ip)
+			if is4 {
+				return fastnetip.Contains4(&kid.Prefix, &ip)
+			}
+			return fastnetip.Contains6(&kid.Prefix, &ip)
 		}
 	}
 
@@ -191,9 +195,16 @@ LOOP:
 			return kid.Value, true
 
 		case *nodes.LeafNode[V]:
-			if kid.Prefix.Contains(ip) {
-				return kid.Value, true
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
 			}
+
 			// reached a path compressed prefix, stop traversing
 			break LOOP
 		}
@@ -297,10 +308,20 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen {
 				break LOOP
 			}
-			return kid.Prefix, kid.Value, true
+
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			}
+			break LOOP
 
 		case *nodes.FringeNode[V]:
 			// the bits of the fringe are defined by the depth

--- a/fastmethodsgenerated.go
+++ b/fastmethodsgenerated.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gaissmai/bart/internal/art"
+	"github.com/gaissmai/bart/internal/fastnetip"
 	"github.com/gaissmai/bart/internal/lpm"
 	"github.com/gaissmai/bart/internal/nodes"
 	"github.com/gaissmai/bart/internal/value"
@@ -74,7 +75,10 @@ func (f *Fast[V]) Contains(ip netip.Addr) bool {
 			return true
 
 		case *nodes.LeafNode[V]:
-			return kid.Prefix.Contains(ip)
+			if is4 {
+				return fastnetip.Contains4(&kid.Prefix, &ip)
+			}
+			return fastnetip.Contains6(&kid.Prefix, &ip)
 		}
 	}
 
@@ -133,9 +137,16 @@ LOOP:
 			return kid.Value, true
 
 		case *nodes.LeafNode[V]:
-			if kid.Prefix.Contains(ip) {
-				return kid.Value, true
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
 			}
+
 			// reached a path compressed prefix, stop traversing
 			break LOOP
 		}
@@ -239,10 +250,20 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen {
 				break LOOP
 			}
-			return kid.Prefix, kid.Value, true
+
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			}
+			break LOOP
 
 		case *nodes.FringeNode[V]:
 			// the bits of the fringe are defined by the depth

--- a/internal/fastnetip/bench_test.go
+++ b/internal/fastnetip/bench_test.go
@@ -1,0 +1,70 @@
+package fastnetip
+
+import (
+	"net/netip"
+	"testing"
+)
+
+var (
+	// Test-Set IPv4
+	pfx4 = netip.MustParsePrefix("10.0.0.0/16")
+	ips4 = []netip.Addr{
+		netip.MustParseAddr("10.0.1.1"),    // Match
+		netip.MustParseAddr("10.0.255.2"),  // Match
+		netip.MustParseAddr("10.1.0.1"),    // No Match
+		netip.MustParseAddr("192.168.1.1"), // No Match
+	}
+
+	// Test-Set IPv6
+	pfx6 = netip.MustParsePrefix("2001:db8:1234::/48")
+	ips6 = []netip.Addr{
+		netip.MustParseAddr("2001:db8:1234::1"),         // Match (hi-Register)
+		netip.MustParseAddr("2001:db8:1234:ffff::ffff"), // Match (hi-Register boundary)
+		netip.MustParseAddr("2001:db8:4321::1"),         // No Match
+		netip.MustParseAddr("fe80::1"),                  // No Match
+	}
+)
+
+// -----------------------------------------------------------------------------
+// IPv4 Benchmarks
+// -----------------------------------------------------------------------------
+
+func BenchmarkContains4_Fast(b *testing.B) {
+	i := 0
+	for b.Loop() {
+		ip := ips4[i&3]
+		_ = Contains4(&pfx4, &ip)
+		i++
+	}
+}
+
+func BenchmarkContains4_Stdlib(b *testing.B) {
+	i := 0
+	for b.Loop() {
+		ip := ips4[i&3]
+		_ = pfx4.Contains(ip)
+		i++
+	}
+}
+
+// -----------------------------------------------------------------------------
+// IPv6 Benchmarks
+// -----------------------------------------------------------------------------
+
+func BenchmarkContains6_Fast(b *testing.B) {
+	i := 0
+	for b.Loop() {
+		ip := ips6[i&3]
+		_ = Contains6(&pfx6, &ip)
+		i++
+	}
+}
+
+func BenchmarkContains6_Stdlib(b *testing.B) {
+	i := 0
+	for b.Loop() {
+		ip := ips6[i&3]
+		_ = pfx6.Contains(ip)
+		i++
+	}
+}

--- a/internal/fastnetip/netip.go
+++ b/internal/fastnetip/netip.go
@@ -1,3 +1,14 @@
+// Package fastnetip provides high-performance, zero-allocation CIDR containment
+// checks by mirroring the memory layout of net/netip.Addr and net/netip.Prefix.
+//
+// By using unsafe pointer casting and separating logic into IP family-specific
+// functions (IPv4 vs IPv6), this package bypasses runtime validity checks,
+// zone validations, and branch mispredictions, enabling full compiler inlining.
+//
+// Prerequisites:
+// Callers must ensure that the provided netip.Prefix and netip.Addr pointers
+// are valid, non-zero, unzoned, and match the corresponding IP version family
+// (IPv4 for Contains4, IPv6 for Contains6).
 package fastnetip
 
 import (
@@ -5,21 +16,30 @@ import (
 	"unsafe"
 )
 
+// uint128 represents an unsigned 128-bit integer split across two 64-bit words (hi and lo).
+// It mirrors the unexported uint128 type used internally by net/netip.
 type uint128 struct {
 	hi uint64
 	lo uint64
 }
 
+// Addr mirrors the memory layout of net/netip.Addr.
 type Addr struct {
 	addr uint128
-	z    uintptr
+	z    uintptr // Mirrors unique.Handle[addrDetail]
 }
 
+// Prefix mirrors the memory layout of net/netip.Prefix.
 type Prefix struct {
 	ip          Addr
 	bitsPlusOne uint8
 }
 
+// Contains4 reports whether the IPv4 prefix pfx contains the IPv4 address ip4.
+//
+// It performs no validity, family, or zone checks. The caller must guarantee
+// that both pfx and ip4 are valid IPv4 instances.
+//
 //nolint:gosec // G115: integer overflow conversion uint64 -> uint32
 func Contains4(pfx *netip.Prefix, ip4 *netip.Addr) bool {
 	ip := (*Addr)(unsafe.Pointer(ip4))
@@ -29,19 +49,26 @@ func Contains4(pfx *netip.Prefix, ip4 *netip.Addr) bool {
 	return uint32((ip.addr.lo^p.ip.addr.lo)>>((32-bits)&63)) == 0
 }
 
+// Contains6 reports whether the IPv6 prefix pfx contains the IPv6 address ip6.
+//
+// It performs no validity, family, or zone checks. The caller must guarantee
+// that both pfx and ip6 are valid IPv6 instances without scoping zones.
 func Contains6(pfx *netip.Prefix, ip6 *netip.Addr) bool {
 	ip := (*Addr)(unsafe.Pointer(ip6))
 	p := (*Prefix)(unsafe.Pointer(pfx))
 
-	return ip.addr.xor(p.ip.addr).and(mask6(int(p.bitsPlusOne) - 1)).isZero()
+	bits := int(p.bitsPlusOne - 1)
+	return ip.addr.xor(p.ip.addr).and(mask6(bits)).isZero()
 }
 
 // ##################################################################################
 
+// isZero reports whether u represents the value zero.
 func (u uint128) isZero() bool {
 	return u.hi|u.lo == 0
 }
 
+// and returns the bitwise AND operation of u and v.
 func (u uint128) and(v uint128) uint128 {
 	return uint128{
 		hi: u.hi & v.hi,
@@ -49,6 +76,7 @@ func (u uint128) and(v uint128) uint128 {
 	}
 }
 
+// xor returns the bitwise XOR operation of u and v.
 func (u uint128) xor(v uint128) uint128 {
 	return uint128{
 		hi: u.hi ^ v.hi,
@@ -56,6 +84,7 @@ func (u uint128) xor(v uint128) uint128 {
 	}
 }
 
+// mask6 returns a 128-bit mask with the topmost n bits set to 1.
 func mask6(n int) uint128 {
 	return uint128{
 		hi: ^(^uint64(0) >> n),

--- a/internal/fastnetip/netip.go
+++ b/internal/fastnetip/netip.go
@@ -1,93 +1,15 @@
-// Package fastnetip provides high-performance, zero-allocation CIDR containment
-// checks by mirroring the memory layout of net/netip.Addr and net/netip.Prefix.
-//
-// By using unsafe pointer casting and separating logic into IP family-specific
-// functions (IPv4 vs IPv6), this package bypasses runtime validity checks,
-// zone validations, and branch mispredictions, enabling full compiler inlining.
-//
-// Prerequisites:
-// Callers must ensure that the provided netip.Prefix and netip.Addr pointers
-// are valid, non-zero, unzoned, and match the corresponding IP version family
-// (IPv4 for Contains4, IPv6 for Contains6).
+//go:build !unsafe
+
 package fastnetip
 
-import (
-	"net/netip"
-	"unsafe"
-)
-
-// uint128 represents an unsigned 128-bit integer split across two 64-bit words (hi and lo).
-// It mirrors the unexported uint128 type used internally by net/netip.
-type uint128 struct {
-	hi uint64
-	lo uint64
-}
-
-// Addr mirrors the memory layout of net/netip.Addr.
-type Addr struct {
-	addr uint128
-	z    uintptr // Mirrors unique.Handle[addrDetail]
-}
-
-// Prefix mirrors the memory layout of net/netip.Prefix.
-type Prefix struct {
-	ip          Addr
-	bitsPlusOne uint8
-}
+import "net/netip"
 
 // Contains4 reports whether the IPv4 prefix pfx contains the IPv4 address ip4.
-//
-// It performs no validity, family, or zone checks. The caller must guarantee
-// that both pfx and ip4 are valid IPv4 instances.
-//
-//nolint:gosec // G115: integer overflow conversion uint64 -> uint32
-func Contains4(pfx *netip.Prefix, ip4 *netip.Addr) bool {
-	ip := (*Addr)(unsafe.Pointer(ip4))
-	p := (*Prefix)(unsafe.Pointer(pfx))
-
-	bits := p.bitsPlusOne - 1
-	return uint32((ip.addr.lo^p.ip.addr.lo)>>((32-bits)&63)) == 0
+func Contains4(pfx *netip.Prefix, ip *netip.Addr) bool {
+	return pfx.Contains(*ip)
 }
 
 // Contains6 reports whether the IPv6 prefix pfx contains the IPv6 address ip6.
-//
-// It performs no validity, family, or zone checks. The caller must guarantee
-// that both pfx and ip6 are valid IPv6 instances without scoping zones.
-func Contains6(pfx *netip.Prefix, ip6 *netip.Addr) bool {
-	ip := (*Addr)(unsafe.Pointer(ip6))
-	p := (*Prefix)(unsafe.Pointer(pfx))
-
-	bits := int(p.bitsPlusOne - 1)
-	return ip.addr.xor(p.ip.addr).and(mask6(bits)).isZero()
-}
-
-// ##################################################################################
-
-// isZero reports whether u represents the value zero.
-func (u uint128) isZero() bool {
-	return u.hi|u.lo == 0
-}
-
-// and returns the bitwise AND operation of u and v.
-func (u uint128) and(v uint128) uint128 {
-	return uint128{
-		hi: u.hi & v.hi,
-		lo: u.lo & v.lo,
-	}
-}
-
-// xor returns the bitwise XOR operation of u and v.
-func (u uint128) xor(v uint128) uint128 {
-	return uint128{
-		hi: u.hi ^ v.hi,
-		lo: u.lo ^ v.lo,
-	}
-}
-
-// mask6 returns a 128-bit mask with the topmost n bits set to 1.
-func mask6(n int) uint128 {
-	return uint128{
-		hi: ^(^uint64(0) >> n),
-		lo: ^uint64(0) << (128 - n),
-	}
+func Contains6(pfx *netip.Prefix, ip *netip.Addr) bool {
+	return pfx.Contains(*ip)
 }

--- a/internal/fastnetip/netip.go
+++ b/internal/fastnetip/netip.go
@@ -1,0 +1,64 @@
+package fastnetip
+
+import (
+	"net/netip"
+	"unsafe"
+)
+
+type uint128 struct {
+	hi uint64
+	lo uint64
+}
+
+type Addr struct {
+	addr uint128
+	z    uintptr
+}
+
+type Prefix struct {
+	ip          Addr
+	bitsPlusOne uint8
+}
+
+//nolint:gosec // G115: integer overflow conversion uint64 -> uint32
+func Contains4(pfx *netip.Prefix, ip4 *netip.Addr) bool {
+	ip := (*Addr)(unsafe.Pointer(ip4))
+	p := (*Prefix)(unsafe.Pointer(pfx))
+
+	bits := p.bitsPlusOne - 1
+	return uint32((ip.addr.lo^p.ip.addr.lo)>>((32-bits)&63)) == 0
+}
+
+func Contains6(pfx *netip.Prefix, ip6 *netip.Addr) bool {
+	ip := (*Addr)(unsafe.Pointer(ip6))
+	p := (*Prefix)(unsafe.Pointer(pfx))
+
+	return ip.addr.xor(p.ip.addr).and(mask6(int(p.bitsPlusOne) - 1)).isZero()
+}
+
+// ##################################################################################
+
+func (u uint128) isZero() bool {
+	return u.hi|u.lo == 0
+}
+
+func (u uint128) and(v uint128) uint128 {
+	return uint128{
+		hi: u.hi & v.hi,
+		lo: u.lo & v.lo,
+	}
+}
+
+func (u uint128) xor(v uint128) uint128 {
+	return uint128{
+		hi: u.hi ^ v.hi,
+		lo: u.lo ^ v.lo,
+	}
+}
+
+func mask6(n int) uint128 {
+	return uint128{
+		hi: ^(^uint64(0) >> n),
+		lo: ^uint64(0) << (128 - n),
+	}
+}

--- a/internal/fastnetip/netip_test.go
+++ b/internal/fastnetip/netip_test.go
@@ -1,0 +1,101 @@
+package fastnetip
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestContains4(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		ip       string
+		expected bool
+	}{
+		// Basic Subnet Tests
+		{"Match /24", "192.168.1.0/24", "192.168.1.42", true},
+		{"No Match /24", "192.168.1.0/24", "192.168.2.42", false},
+
+		// Boundary / Edge Cases
+		{"First IP in /24 (Network)", "10.0.0.0/24", "10.0.0.0", true},
+		{"Last IP in /24 (Broadcast)", "10.0.0.0/24", "10.0.0.255", true},
+		{"IP right after Broadcast", "10.0.0.0/24", "10.0.1.0", false},
+
+		// Extreme Prefixes (/0 and /32)
+		{"Match /0 (Any IP)", "0.0.0.0/0", "1.2.3.4", true},
+		{"Match /32 Exact", "172.16.0.1/32", "172.16.0.1", true},
+		{"No Match /32", "172.16.0.1/32", "172.16.0.2", false},
+
+		// Single-Bit Boundaries
+		{"Match /31 First", "10.0.0.0/31", "10.0.0.0", true},
+		{"Match /31 Second", "10.0.0.0/31", "10.0.0.1", true},
+		{"No Match /31 Third", "10.0.0.0/31", "10.0.0.2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pfx := netip.MustParsePrefix(tt.prefix)
+			ip := netip.MustParseAddr(tt.ip)
+
+			// 1. Dein fastnetip Call
+			got := Contains4(&pfx, &ip)
+			if got != tt.expected {
+				t.Errorf("Contains4(%s, %s) = %v; want %v", tt.prefix, tt.ip, got, tt.expected)
+			}
+
+			// 2. Paritäts-Check gegen die Go stdlib
+			stdlibGot := pfx.Contains(ip)
+			if got != stdlibGot {
+				t.Errorf("Mismatch with stdlib for %s in %s! fastnetip=%v, stdlib=%v", tt.ip, tt.prefix, got, stdlibGot)
+			}
+		})
+	}
+}
+
+func TestContains6(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		ip       string
+		expected bool
+	}{
+		// Basic Subnet Tests
+		{"Match /32", "2001:db8::/32", "2001:db8::1", true},
+		{"No Match /32", "2001:db8::/32", "2001:db9::1", false},
+
+		// Register-Boundary Cases (hi vs. lo Register: /64)
+		{"Match /64 (hi-Register exact)", "2001:db8:1:2::/64", "2001:db8:1:2:ffff:ffff:ffff:ffff", true},
+		{"No Match /64 (hi-Register diff)", "2001:db8:1:2::/64", "2001:db8:1:3::1", false},
+		{"Match /65 (crosses into lo-Register)", "2001:db8::/65", "2001:db8:0:0:7fff:ffff:ffff:ffff", true},
+		{"No Match /65", "2001:db8::/65", "2001:db8:0:0:8000::", false},
+
+		// Extreme Prefixes (/0 and /128)
+		{"Match /0 (Any IPv6)", "::/0", "2607:f8b0:4005:805::200e", true},
+		{"Match /128 Exact", "2001:db8::1234/128", "2001:db8::1234", true},
+		{"No Match /128", "2001:db8::1234/128", "2001:db8::1235", false},
+
+		// High-Bit lo-Register Limits
+		{"Match /127 First", "fe80::10/127", "fe80::10", true},
+		{"Match /127 Second", "fe80::10/127", "fe80::11", true},
+		{"No Match /127 Third", "fe80::10/127", "fe80::12", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pfx := netip.MustParsePrefix(tt.prefix)
+			ip := netip.MustParseAddr(tt.ip)
+
+			// 1. Dein fastnetip Call
+			got := Contains6(&pfx, &ip)
+			if got != tt.expected {
+				t.Errorf("Contains6(%s, %s) = %v; want %v", tt.prefix, tt.ip, got, tt.expected)
+			}
+
+			// 2. Paritäts-Check gegen die Go stdlib
+			stdlibGot := pfx.Contains(ip)
+			if got != stdlibGot {
+				t.Errorf("Mismatch with stdlib for %s in %s! fastnetip=%v, stdlib=%v", tt.ip, tt.prefix, got, stdlibGot)
+			}
+		})
+	}
+}

--- a/internal/fastnetip/netip_test.go
+++ b/internal/fastnetip/netip_test.go
@@ -37,13 +37,11 @@ func TestContains4(t *testing.T) {
 			pfx := netip.MustParsePrefix(tt.prefix)
 			ip := netip.MustParseAddr(tt.ip)
 
-			// 1. Dein fastnetip Call
 			got := Contains4(&pfx, &ip)
 			if got != tt.expected {
 				t.Errorf("Contains4(%s, %s) = %v; want %v", tt.prefix, tt.ip, got, tt.expected)
 			}
 
-			// 2. Paritäts-Check gegen die Go stdlib
 			stdlibGot := pfx.Contains(ip)
 			if got != stdlibGot {
 				t.Errorf("Mismatch with stdlib for %s in %s! fastnetip=%v, stdlib=%v", tt.ip, tt.prefix, got, stdlibGot)
@@ -85,13 +83,11 @@ func TestContains6(t *testing.T) {
 			pfx := netip.MustParsePrefix(tt.prefix)
 			ip := netip.MustParseAddr(tt.ip)
 
-			// 1. Dein fastnetip Call
 			got := Contains6(&pfx, &ip)
 			if got != tt.expected {
 				t.Errorf("Contains6(%s, %s) = %v; want %v", tt.prefix, tt.ip, got, tt.expected)
 			}
 
-			// 2. Paritäts-Check gegen die Go stdlib
 			stdlibGot := pfx.Contains(ip)
 			if got != stdlibGot {
 				t.Errorf("Mismatch with stdlib for %s in %s! fastnetip=%v, stdlib=%v", tt.ip, tt.prefix, got, stdlibGot)

--- a/internal/fastnetip/netip_unsafe.go
+++ b/internal/fastnetip/netip_unsafe.go
@@ -1,0 +1,95 @@
+//go:build unsafe
+
+// Package fastnetip provides high-performance, zero-allocation CIDR containment
+// checks by mirroring the memory layout of net/netip.Addr and net/netip.Prefix.
+//
+// By using unsafe pointer casting and separating logic into IP family-specific
+// functions (IPv4 vs IPv6), this package bypasses runtime validity checks,
+// zone validations, and branch mispredictions, enabling full compiler inlining.
+//
+// Prerequisites:
+// Callers must ensure that the provided netip.Prefix and netip.Addr pointers
+// are valid, non-zero, unzoned, and match the corresponding IP version family
+// (IPv4 for Contains4, IPv6 for Contains6).
+package fastnetip
+
+import (
+	"net/netip"
+	"unsafe"
+)
+
+// uint128 represents an unsigned 128-bit integer split across two 64-bit words (hi and lo).
+// It mirrors the unexported uint128 type used internally by net/netip.
+type uint128 struct {
+	hi uint64
+	lo uint64
+}
+
+// Addr mirrors the memory layout of net/netip.Addr.
+type Addr struct {
+	addr uint128
+	z    uintptr // Mirrors unique.Handle[addrDetail]
+}
+
+// Prefix mirrors the memory layout of net/netip.Prefix.
+type Prefix struct {
+	ip          Addr
+	bitsPlusOne uint8
+}
+
+// Contains4 reports whether the IPv4 prefix pfx contains the IPv4 address ip4.
+//
+// It performs no validity, family, or zone checks. The caller must guarantee
+// that both pfx and ip4 are valid IPv4 instances.
+//
+//nolint:gosec // G115: integer overflow conversion uint64 -> uint32
+func Contains4(pfx *netip.Prefix, ip4 *netip.Addr) bool {
+	ip := (*Addr)(unsafe.Pointer(ip4))
+	p := (*Prefix)(unsafe.Pointer(pfx))
+
+	bits := p.bitsPlusOne - 1
+	return uint32((ip.addr.lo^p.ip.addr.lo)>>((32-bits)&63)) == 0
+}
+
+// Contains6 reports whether the IPv6 prefix pfx contains the IPv6 address ip6.
+//
+// It performs no validity, family, or zone checks. The caller must guarantee
+// that both pfx and ip6 are valid IPv6 instances without scoping zones.
+func Contains6(pfx *netip.Prefix, ip6 *netip.Addr) bool {
+	ip := (*Addr)(unsafe.Pointer(ip6))
+	p := (*Prefix)(unsafe.Pointer(pfx))
+
+	bits := int(p.bitsPlusOne - 1)
+	return ip.addr.xor(p.ip.addr).and(mask6(bits)).isZero()
+}
+
+// ##################################################################################
+
+// isZero reports whether u represents the value zero.
+func (u uint128) isZero() bool {
+	return u.hi|u.lo == 0
+}
+
+// and returns the bitwise AND operation of u and v.
+func (u uint128) and(v uint128) uint128 {
+	return uint128{
+		hi: u.hi & v.hi,
+		lo: u.lo & v.lo,
+	}
+}
+
+// xor returns the bitwise XOR operation of u and v.
+func (u uint128) xor(v uint128) uint128 {
+	return uint128{
+		hi: u.hi ^ v.hi,
+		lo: u.lo ^ v.lo,
+	}
+}
+
+// mask6 returns a 128-bit mask with the topmost n bits set to 1.
+func mask6(n int) uint128 {
+	return uint128{
+		hi: ^(^uint64(0) >> n),
+		lo: ^uint64(0) << (128 - n),
+	}
+}

--- a/internal/fastnetip/uint128_test.go
+++ b/internal/fastnetip/uint128_test.go
@@ -1,0 +1,154 @@
+package fastnetip
+
+import "testing"
+
+func TestUint128IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		u    uint128
+		want bool
+	}{
+		{
+			name: "both zero",
+			u:    uint128{hi: 0, lo: 0},
+			want: true,
+		},
+		{
+			name: "hi non-zero",
+			u:    uint128{hi: 1, lo: 0},
+			want: false,
+		},
+		{
+			name: "lo non-zero",
+			u:    uint128{hi: 0, lo: 1},
+			want: false,
+		},
+		{
+			name: "both max uint64",
+			u:    uint128{hi: ^uint64(0), lo: ^uint64(0)},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.u.isZero(); got != tt.want {
+				t.Errorf("uint128.isZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUint128And(t *testing.T) {
+	tests := []struct {
+		name string
+		u    uint128
+		v    uint128
+		want uint128
+	}{
+		{
+			name: "zero and zero",
+			u:    uint128{hi: 0, lo: 0},
+			v:    uint128{hi: 0, lo: 0},
+			want: uint128{hi: 0, lo: 0},
+		},
+		{
+			name: "all bits set and zero",
+			u:    uint128{hi: ^uint64(0), lo: ^uint64(0)},
+			v:    uint128{hi: 0, lo: 0},
+			want: uint128{hi: 0, lo: 0},
+		},
+		{
+			name: "pattern bitwise AND",
+			u:    uint128{hi: 0xF0F0_F0F0_F0F0_F0F0, lo: 0x0F0F_0F0F_0F0F_0F0F},
+			v:    uint128{hi: 0xFFFF_0000_FFFF_0000, lo: 0x0000_FFFF_0000_FFFF},
+			want: uint128{hi: 0xF0F0_0000_F0F0_0000, lo: 0x0000_0F0F_0000_0F0F},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.u.and(tt.v); got != tt.want {
+				t.Errorf("uint128.and() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUint128Xor(t *testing.T) {
+	tests := []struct {
+		name string
+		u    uint128
+		v    uint128
+		want uint128
+	}{
+		{
+			name: "same values return zero",
+			u:    uint128{hi: 0x1234, lo: 0x5678},
+			v:    uint128{hi: 0x1234, lo: 0x5678},
+			want: uint128{hi: 0, lo: 0},
+		},
+		{
+			name: "complementary bits set all bits",
+			u:    uint128{hi: 0xAAAA_AAAA_AAAA_AAAA, lo: 0x5555_5555_5555_5555},
+			v:    uint128{hi: 0x5555_5555_5555_5555, lo: 0xAAAA_AAAA_AAAA_AAAA},
+			want: uint128{hi: ^uint64(0), lo: ^uint64(0)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.u.xor(tt.v); got != tt.want {
+				t.Errorf("uint128.xor() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMask6(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want uint128
+	}{
+		{
+			name: "prefix length 0",
+			n:    0,
+			want: uint128{hi: 0x0, lo: 0x0},
+		},
+		{
+			name: "prefix length 1",
+			n:    1,
+			want: uint128{hi: 0x8000_0000_0000_0000, lo: 0x0},
+		},
+		{
+			name: "prefix length 32 (/32 IPv4-in-IPv6 or subnets)",
+			n:    32,
+			want: uint128{hi: 0xFFFF_FFFF_0000_0000, lo: 0x0},
+		},
+		{
+			name: "prefix length 64 (standard IPv6 subnet boundary)",
+			n:    64,
+			want: uint128{hi: 0xFFFF_FFFF_FFFF_FFFF, lo: 0x0},
+		},
+		{
+			name: "prefix length 65",
+			n:    65,
+			want: uint128{hi: 0xFFFF_FFFF_FFFF_FFFF, lo: 0x8000_0000_0000_0000},
+		},
+		{
+			name: "prefix length 128 (host mask)",
+			n:    128,
+			want: uint128{hi: 0xFFFF_FFFF_FFFF_FFFF, lo: 0xFFFF_FFFF_FFFF_FFFF},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mask6(tt.n); got != tt.want {
+				t.Errorf("mask6(%d) = uint128{hi: %#016x, lo: %#016x}, want uint128{hi: %#016x, lo: %#016x}",
+					tt.n, got.hi, got.lo, tt.want.hi, tt.want.lo)
+			}
+		})
+	}
+}

--- a/internal/fastnetip/uint128_test.go
+++ b/internal/fastnetip/uint128_test.go
@@ -1,3 +1,5 @@
+//go:build unsafe
+
 package fastnetip
 
 import "testing"

--- a/litemethodsgenerated.go
+++ b/litemethodsgenerated.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gaissmai/bart/internal/art"
+	"github.com/gaissmai/bart/internal/fastnetip"
 	"github.com/gaissmai/bart/internal/lpm"
 	"github.com/gaissmai/bart/internal/nodes"
 	"github.com/gaissmai/bart/internal/value"
@@ -74,7 +75,10 @@ func (f *liteTable[V]) Contains(ip netip.Addr) bool {
 			return true
 
 		case *nodes.LeafNode[V]:
-			return kid.Prefix.Contains(ip)
+			if is4 {
+				return fastnetip.Contains4(&kid.Prefix, &ip)
+			}
+			return fastnetip.Contains6(&kid.Prefix, &ip)
 		}
 	}
 
@@ -133,9 +137,16 @@ LOOP:
 			return kid.Value, true
 
 		case *nodes.LeafNode[V]:
-			if kid.Prefix.Contains(ip) {
-				return kid.Value, true
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Value, true
+				}
 			}
+
 			// reached a path compressed prefix, stop traversing
 			break LOOP
 		}
@@ -239,10 +250,20 @@ LOOP:
 
 		case *nodes.LeafNode[V]:
 			// reached a path compressed prefix, stop traversing
-			if kid.Prefix.Bits() > pfxLen || !kid.Prefix.Contains(ip) {
+			if kid.Prefix.Bits() > pfxLen {
 				break LOOP
 			}
-			return kid.Prefix, kid.Value, true
+
+			if is4 {
+				if fastnetip.Contains4(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			} else {
+				if fastnetip.Contains6(&kid.Prefix, &ip) {
+					return kid.Prefix, kid.Value, true
+				}
+			}
+			break LOOP
 
 		case *nodes.FringeNode[V]:
 			// the bits of the fringe are defined by the depth


### PR DESCRIPTION
@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved IPv4 and IPv6 prefix containment checks across lookup and matching operations.
  * Optimized longest-prefix matching while preserving existing results.

* **Testing**
  * Added comprehensive IPv4 and IPv6 containment coverage, including boundary and negative cases.
  * Added performance benchmarks against the standard library.
  * Expanded coverage for internal bitwise and masking operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->