### PR TITLE
Reject IPv6 Zones in Contains and Lookup Implementations

### DIFF
--- a/bartmethodsgenerated.go
+++ b/bartmethodsgenerated.go
@@ -38,7 +38,7 @@ func (t *Table[V]) sizeUpdate(is4 bool, delta int) {
 }
 
 // Contains reports whether any stored prefix covers the given IP address.
-// Returns false for invalid IP addresses.
+// Returns false for invalid IP addresses or for IPv6 addresses with zones.
 //
 // This performs longest-prefix matching and returns true if any prefix
 // in the routing table contains the IP address, regardless of the associated value.
@@ -51,6 +51,10 @@ func (f *Table[V]) Contains(ip netip.Addr) bool {
 	// if ip is invalid, AsSlice() returns nil, Contains returns false.
 	is4 := ip.Is4()
 	n := f.rootNodeByVersion(is4)
+
+	if ip.Zone() != "" {
+		return false
+	}
 
 	for _, octet := range ip.AsSlice() {
 		// for contains, any lpm match is good enough, no backtracking needed
@@ -89,9 +93,10 @@ func (f *Table[V]) Contains(ip netip.Addr) bool {
 // best matching route for a destination address.
 //
 // Returns the associated value and true if a matching prefix is found.
-// Returns zero value and false if no prefix contains the address.
+// Returns zero value and false if no prefix contains the address or
+// for invalid IP addresses or IPv6 addresses with zones.
 func (t *Table[V]) Lookup(ip netip.Addr) (val V, ok bool) {
-	if !ip.IsValid() {
+	if !ip.IsValid() || ip.Zone() != "" {
 		return val, ok
 	}
 

--- a/barttestsgenerated_test.go
+++ b/barttestsgenerated_test.go
@@ -222,6 +222,70 @@ func TestTableLookupCompare_Table(t *testing.T) {
 	}
 }
 
+func TestTableContainsWithZone_Table(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(Table[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := tbl.Contains(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Contains IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
+func TestTableLookupWithZone_Table(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(Table[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		_, got := tbl.Lookup(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Lookup IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
 func TestTableLookupPrefixUnmasked_Table(t *testing.T) {
 	// test that the pfx must not be masked on input for LookupPrefix
 	t.Parallel()

--- a/commonmethods_tmpl.go
+++ b/commonmethods_tmpl.go
@@ -97,7 +97,7 @@ func (t *_TABLE_TYPE[V]) sizeUpdate(is4 bool, delta int) {
 }
 
 // Contains reports whether any stored prefix covers the given IP address.
-// Returns false for invalid IP addresses.
+// Returns false for invalid IP addresses or for IPv6 addresses with zones.
 //
 // This performs longest-prefix matching and returns true if any prefix
 // in the routing table contains the IP address, regardless of the associated value.
@@ -110,6 +110,10 @@ func (f *_TABLE_TYPE[V]) Contains(ip netip.Addr) bool {
 	// if ip is invalid, AsSlice() returns nil, Contains returns false.
 	is4 := ip.Is4()
 	n := f.rootNodeByVersion(is4)
+
+	if ip.Zone() != "" {
+		return false
+	}
 
 	for _, octet := range ip.AsSlice() {
 		// for contains, any lpm match is good enough, no backtracking needed
@@ -148,9 +152,10 @@ func (f *_TABLE_TYPE[V]) Contains(ip netip.Addr) bool {
 // best matching route for a destination address.
 //
 // Returns the associated value and true if a matching prefix is found.
-// Returns zero value and false if no prefix contains the address.
+// Returns zero value and false if no prefix contains the address or
+// for invalid IP addresses or IPv6 addresses with zones.
 func (t *_TABLE_TYPE[V]) Lookup(ip netip.Addr) (val V, ok bool) {
-	if !ip.IsValid() {
+	if !ip.IsValid() || ip.Zone() != "" {
 		return val, ok
 	}
 

--- a/commontests_tmpl.go
+++ b/commontests_tmpl.go
@@ -291,6 +291,70 @@ func TestTableLookupCompare__TABLE_TYPE(t *testing.T) {
 	}
 }
 
+func TestTableContainsWithZone__TABLE_TYPE(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(_TABLE_TYPE[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := tbl.Contains(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Contains IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
+func TestTableLookupWithZone__TABLE_TYPE(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(_TABLE_TYPE[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		_, got := tbl.Lookup(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Lookup IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
 func TestTableLookupPrefixUnmasked__TABLE_TYPE(t *testing.T) {
 	// test that the pfx must not be masked on input for LookupPrefix
 	t.Parallel()

--- a/fastmethodsgenerated.go
+++ b/fastmethodsgenerated.go
@@ -38,7 +38,7 @@ func (t *Fast[V]) sizeUpdate(is4 bool, delta int) {
 }
 
 // Contains reports whether any stored prefix covers the given IP address.
-// Returns false for invalid IP addresses.
+// Returns false for invalid IP addresses or for IPv6 addresses with zones.
 //
 // This performs longest-prefix matching and returns true if any prefix
 // in the routing table contains the IP address, regardless of the associated value.
@@ -51,6 +51,10 @@ func (f *Fast[V]) Contains(ip netip.Addr) bool {
 	// if ip is invalid, AsSlice() returns nil, Contains returns false.
 	is4 := ip.Is4()
 	n := f.rootNodeByVersion(is4)
+
+	if ip.Zone() != "" {
+		return false
+	}
 
 	for _, octet := range ip.AsSlice() {
 		// for contains, any lpm match is good enough, no backtracking needed
@@ -89,9 +93,10 @@ func (f *Fast[V]) Contains(ip netip.Addr) bool {
 // best matching route for a destination address.
 //
 // Returns the associated value and true if a matching prefix is found.
-// Returns zero value and false if no prefix contains the address.
+// Returns zero value and false if no prefix contains the address or
+// for invalid IP addresses or IPv6 addresses with zones.
 func (t *Fast[V]) Lookup(ip netip.Addr) (val V, ok bool) {
-	if !ip.IsValid() {
+	if !ip.IsValid() || ip.Zone() != "" {
 		return val, ok
 	}
 

--- a/fasttestsgenerated_test.go
+++ b/fasttestsgenerated_test.go
@@ -222,6 +222,70 @@ func TestTableLookupCompare_Fast(t *testing.T) {
 	}
 }
 
+func TestTableContainsWithZone_Fast(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(Fast[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := tbl.Contains(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Contains IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
+func TestTableLookupWithZone_Fast(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(Fast[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		_, got := tbl.Lookup(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Lookup IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
 func TestTableLookupPrefixUnmasked_Fast(t *testing.T) {
 	// test that the pfx must not be masked on input for LookupPrefix
 	t.Parallel()

--- a/internal/tests/random/random.go
+++ b/internal/tests/random/random.go
@@ -53,6 +53,9 @@ func IP6(prng *rand.Rand) netip.Addr {
 		//nolint:gosec // G115: integer overflow conversion uint -> byte
 		b[i] = byte(prng.UintN(256))
 	}
+	if prng.IntN(100) == 50 {
+		return netip.AddrFrom16(b).WithZone("eth0")
+	}
 	return netip.AddrFrom16(b)
 }
 

--- a/internal/tests/random/random_test.go
+++ b/internal/tests/random/random_test.go
@@ -121,8 +121,9 @@ func TestIP(t *testing.T) {
 
 	hasIPv4 := false
 	hasIPv6 := false
+	hasZone := false
 
-	for range 100 {
+	for range 10_000 {
 		ip := IP(prng)
 
 		if !ip.IsValid() {
@@ -135,14 +136,21 @@ func TestIP(t *testing.T) {
 		if ip.Is6() {
 			hasIPv6 = true
 		}
+		if ip.Is6() && ip.Zone() != "" {
+			hasZone = true
+		}
 	}
 
-	// With 100 iterations, we should see both IPv4 and IPv6
+	// With 10_000 iterations, we should see both IPv4 and IPv6
+	// and some IPv6 with zone
 	if !hasIPv4 {
 		t.Error("IP never generated IPv4 address")
 	}
 	if !hasIPv6 {
 		t.Error("IP never generated IPv6 address")
+	}
+	if !hasZone {
+		t.Error("IP never generated IPv6 with zone")
 	}
 }
 

--- a/litemethodsgenerated.go
+++ b/litemethodsgenerated.go
@@ -38,7 +38,7 @@ func (t *liteTable[V]) sizeUpdate(is4 bool, delta int) {
 }
 
 // Contains reports whether any stored prefix covers the given IP address.
-// Returns false for invalid IP addresses.
+// Returns false for invalid IP addresses or for IPv6 addresses with zones.
 //
 // This performs longest-prefix matching and returns true if any prefix
 // in the routing table contains the IP address, regardless of the associated value.
@@ -51,6 +51,10 @@ func (f *liteTable[V]) Contains(ip netip.Addr) bool {
 	// if ip is invalid, AsSlice() returns nil, Contains returns false.
 	is4 := ip.Is4()
 	n := f.rootNodeByVersion(is4)
+
+	if ip.Zone() != "" {
+		return false
+	}
 
 	for _, octet := range ip.AsSlice() {
 		// for contains, any lpm match is good enough, no backtracking needed
@@ -89,9 +93,10 @@ func (f *liteTable[V]) Contains(ip netip.Addr) bool {
 // best matching route for a destination address.
 //
 // Returns the associated value and true if a matching prefix is found.
-// Returns zero value and false if no prefix contains the address.
+// Returns zero value and false if no prefix contains the address or
+// for invalid IP addresses or IPv6 addresses with zones.
 func (t *liteTable[V]) Lookup(ip netip.Addr) (val V, ok bool) {
-	if !ip.IsValid() {
+	if !ip.IsValid() || ip.Zone() != "" {
 		return val, ok
 	}
 

--- a/litetestsgenerated_test.go
+++ b/litetestsgenerated_test.go
@@ -222,6 +222,70 @@ func TestTableLookupCompare_liteTable(t *testing.T) {
 	}
 }
 
+func TestTableContainsWithZone_liteTable(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(liteTable[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := tbl.Contains(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Contains IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
+func TestTableLookupWithZone_liteTable(t *testing.T) {
+	// test that the IPv6 address with zone never matches
+	t.Parallel()
+
+	tbl := new(liteTable[any])
+	tbl.Insert(mpp("2001:db8::/32"), nil)
+
+	tests := []struct {
+		name   string
+		ip     netip.Addr
+		wantOk bool
+	}{
+		{
+			name:   "with zone",
+			ip:     mpa("2001:db8::1%enps01"),
+			wantOk: false,
+		},
+		{
+			name:   "without zone",
+			ip:     netip.MustParseAddr("2001:db8::1"),
+			wantOk: true,
+		},
+	}
+
+	for _, tc := range tests {
+		_, got := tbl.Lookup(tc.ip)
+		if got != tc.wantOk {
+			t.Errorf("Lookup IPv6 %s, got: %v, want: %v", tc.name, got, tc.wantOk)
+		}
+	}
+}
+
 func TestTableLookupPrefixUnmasked_liteTable(t *testing.T) {
 	// test that the pfx must not be masked on input for LookupPrefix
 	t.Parallel()


### PR DESCRIPTION
@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Contains` and `Lookup` now consistently reject IPv6 addresses that include zone identifiers.
  * Zoned IPv6 addresses return `false` from `Contains`; `Lookup` returns no result.

* **Documentation**
  * Updated method documentation to clarify handling of IPv6 addresses with zones.

* **Tests**
  * Expanded randomized IPv6 test coverage to occasionally include zone identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->